### PR TITLE
Enforce PR workflow and upgrade heartbeat to Opus

### DIFF
--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -49,13 +49,24 @@ Use the `ralph_loop` skill methodology. Work on multiple tasks within the time l
 4. `RECURRING` tasks stay in Open — they repeat every cycle.
 5. If a task needs permissions you don't have, mark it blocked with a note.
 
-**PR workflow (for README roadmap tasks):**
-1. `git checkout main && git pull`
-2. `git checkout -b heartbeat/<short-name>`
-3. Implement, commit with descriptive message
-4. `git push -u origin heartbeat/<short-name>`
-5. `gh pr create --title "..." --body "..."`
-6. Update task sub-bullets with the PR link
+### Git rules: PRs vs direct push
+
+**MUST use a PR — any change to a codebase repo (skills, dotfiles, projects, etc.):**
+- NEVER commit directly to main in any codebase repo.
+- Always create a feature branch, push it, and open a PR. The human merges.
+- This applies to ALL code changes: bug fixes, docs updates (README, CHANGELOG), config, refactors — everything.
+
+```bash
+git checkout main && git pull
+git checkout -b heartbeat/<short-name>
+# ... implement, commit ...
+git push -u origin heartbeat/<short-name>
+gh pr create --title "..." --body "..."
+```
+
+**Direct push to main OK — obsidian vault and personal knowledge stores only:**
+- Task file updates, heartbeat log, questions, hierarchical memory, knowledge graph notes.
+- These live in the obsidian vault which is your working scratchpad.
 
 ### 3. Save state
 
@@ -67,7 +78,7 @@ git -C $OBSIDIAN_DIR commit -m "heartbeat: <summary of what changed>"
 git -C $OBSIDIAN_DIR push
 ```
 
-This covers updates to: task file, heartbeat log, questions, hierarchical memory, knowledge graph notes.
+This covers updates to: task file, heartbeat log, questions, hierarchical memory, knowledge graph notes. These are the ONLY repos where direct push to main is allowed.
 
 ## Permissions
 

--- a/skills/heartbeat/scripts/heartbeat.sh
+++ b/skills/heartbeat/scripts/heartbeat.sh
@@ -98,7 +98,7 @@ set +e
             "Bash(uv run python *)" \
         --max-turns "$MAX_TURNS" \
         --max-budget-usd "$MAX_BUDGET_USD" \
-        --model sonnet \
+        --model opus \
         "Use your heartbeat skill. Task file: $TASKS_FILE. Obsidian dir: $OBSIDIAN_DIR. Time limit: $WORK_MINUTES minutes. Current time: $(date -u +%Y-%m-%dT%H:%M:%SZ)."
 ) &
 claude_pid=$!


### PR DESCRIPTION
## Summary
- **PR enforcement**: Replaced the narrow "PR workflow (for README roadmap tasks)" with a dedicated "Git rules: PRs vs direct push" section that makes it unambiguous: ALL changes to codebase repos require a branch + PR. Only obsidian vault/personal knowledge stores can push to main directly.
- **Model upgrade**: Changed heartbeat model from `sonnet` to `opus` (4.6).

Motivated by a heartbeat run that committed documentation fixes directly to main without a branch or PR.

## Test plan
- [ ] Verify SKILL.md reads clearly — the git rules section should leave no ambiguity
- [ ] Verify heartbeat.sh uses `--model opus`
- [ ] Next heartbeat cycle should create PRs for any codebase changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)