### PR TITLE
Speed up CI: move heavy deps to optional extras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help: ## Show this help
 
 install: ## Install all dependencies, settings, and local skills
 	uv python install
-	uv sync --locked --all-groups
+	uv sync --locked --all-extras --all-groups
 	uv run pre-commit install
 	uv run playwright install chromium
 	$(MAKE) install-local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,13 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "click>=8.1.0",
-    "marker-pdf>=1.0.0",
-    "playwright>=1.50.0",
     "pydantic-ai>=0.0.31",
     "python-frontmatter>=1.1.0",
 ]
+
+[project.optional-dependencies]
+pdf = ["marker-pdf>=1.0.0"]
+browser = ["playwright>=1.50.0"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -25,10 +25,16 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
-    { name = "marker-pdf" },
-    { name = "playwright" },
     { name = "pydantic-ai" },
     { name = "python-frontmatter" },
+]
+
+[package.optional-dependencies]
+browser = [
+    { name = "playwright" },
+]
+pdf = [
+    { name = "marker-pdf" },
 ]
 
 [package.dev-dependencies]
@@ -43,11 +49,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
-    { name = "marker-pdf", specifier = ">=1.0.0" },
-    { name = "playwright", specifier = ">=1.50.0" },
+    { name = "marker-pdf", marker = "extra == 'pdf'", specifier = ">=1.0.0" },
+    { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.50.0" },
     { name = "pydantic-ai", specifier = ">=0.0.31" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
 ]
+provides-extras = ["pdf", "browser"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Move `marker-pdf` (pulls in torch + CUDA ~3.8GB) and `playwright` (44MB) from `[project] dependencies` to `[project.optional-dependencies]` as `pdf` and `browser` extras
- `make install` now uses `--all-extras --all-groups` (unchanged behavior for local dev)
- `make install-ci` already uses `--group dev` which skips extras — no torch/CUDA download

Expected CI install time: ~37s → ~5s (eliminating ~4GB of unnecessary downloads).

All 154 tests pass locally. No test imports marker-pdf or playwright.

## Test plan
- [ ] CI passes on this PR (self-validating — if it passes, the lighter deps work)
- [ ] Verify `make install` still gets all deps locally
- [ ] Check CI timing improvement in the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)