### PR TITLE
Add CODEOWNERS for sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Sensitive paths — require explicit human review.
+# Since agents push as @zachmayer, this acts as a reminder rather than
+# a hard gate (GitHub can't enforce self-review). The real gate is
+# branch protection + manual merge.
+
+# CI and deployment
+.github/workflows/  @zachmayer
+.github/CODEOWNERS  @zachmayer
+
+# Agent infrastructure (prevent self-modification)
+skills/heartbeat/scripts/heartbeat.sh  @zachmayer
+skills/heartbeat/scripts/*.plist       @zachmayer
+Makefile                               @zachmayer
+
+# Dependency management
+pyproject.toml  @zachmayer
+uv.lock         @zachmayer


### PR DESCRIPTION
## Summary
- Protects CI workflows, agent infrastructure (heartbeat.sh, plist), and dependency files (pyproject.toml, uv.lock)
- Acts as documentation of sensitive paths — since agents push as `@zachmayer`, GitHub can't enforce self-review, but CODEOWNERS makes the intent explicit
- Part of Heartbeat v2 migration (guardrail #7 in the design doc)

## Note on self-review
With a single-owner repo where agents push as the owner, CODEOWNERS can't enforce required reviews. The actual gates are:
- Branch protection (status checks must pass)
- Manual merge (human clicks the button)
- CODEOWNERS serves as a signal for which files need extra scrutiny

## Test plan
- [x] No code changes, just config

🤖 Generated with [Claude Code](https://claude.com/claude-code)