### PR TITLE
Add session_planner skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- 24 agent skills following the Agent Skills open standard
+- 25 agent skills following the Agent Skills open standard
 - **Capture skills** (5): hierarchical_memory, web_grab, pdf_to_markdown, remember_session, skill_stealer
-- **Organize skills** (3): obsidian, heartbeat, private_repo
+- **Organize skills** (4): obsidian, heartbeat, private_repo, session_planner
 - **Process skills** (7): ultra_think, mental_models, ask_questions, discussion_partners, data_science, forecast, lean_prover
 - **Build skills** (9): ralph_loop, staff_engineer, concise_writing, gh_cli, prompt_evolution, llm_judge, pr_review, api_key_checker, skill_pruner
 - `status` command for memory aggregation staleness detection

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Skills are grouped by their role in the capture → organize → process pipelin
 | [obsidian](skills/obsidian/) | Prompt | Read, write, search, and link notes in a git-backed Obsidian vault |
 | [heartbeat](skills/heartbeat/) | Shell | launchd-based autonomous maintenance: aggregate memory, process tasks |
 | [private_repo](skills/private_repo/) | Prompt | Create or connect private GitHub repos for git-backed storage |
+| [session_planner](skills/session_planner/) | Prompt | Plan a focused work session from memory, tasks, and context |
 
 ### Process
 
@@ -112,6 +113,8 @@ graph LR
     hierarchical_memory --> private_repo
     web_grab --> obsidian
     lean_prover --> discussion_partners
+    session_planner --> hierarchical_memory
+    session_planner --> obsidian
 ```
 
 Standalone skills (no imports): `api_key_checker`, `concise_writing`, `data_science`, `forecast`, `gh_cli`, `pdf_to_markdown`, `pr_review`, `skill_pruner`, `skill_stealer`
@@ -234,7 +237,7 @@ Major improvements, curated by human and Claude together.
 - [ ] **Complexity router** — Assess complexity (simple/medium/complex), route to appropriate effort level.
 - [ ] **Checkpoint system** — Mandatory review at fixed intervals, attempt budgets.
 - [ ] **Context compiler** — Assemble structured context docs from git diffs, files, memory, obsidian. Automates the PR review pattern.
-- [ ] **Session planner** — On session start, read memory + tasks + todos, propose work plan. Lighter than `ralph_loop`.
+- [x] **Session planner** — On session start, read memory + tasks + todos, propose work plan. Lighter than `ralph_loop`.
 - [ ] **Capture inbox** — Smart routing for any input. Routes by scope + audience to the right destination: memory daily log (ephemeral), heartbeat tasks (recurring/future), obsidian knowledge_graph (durable knowledge), CLAUDE.md (repo-specific agent guidance), or README.md (repo dev memory).
 - [ ] **Claude constitution** — A skill encoding the user's values, principles, and preferences as a constitutional document. Applied when making judgment calls.
 - [ ] **Prompt report** — Analyze prompt effectiveness: token budget, clarity, coverage gaps. Human TODO.

--- a/skills/session_planner/SKILL.md
+++ b/skills/session_planner/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: session_planner
+description: >
+  Plan a focused work session from memory, tasks, and context. Use at the
+  start of a work session, when the user says "what should I work on", or
+  when resuming after a break. Do NOT use mid-session or for task execution
+  (use ralph_loop for that).
+---
+
+# Session Planner
+
+Read available context, then propose a focused work plan for this session.
+
+## Inputs
+
+Gather these (skip any that don't exist):
+
+1. **Hierarchical memory** — `read-overall` for current priorities and context
+2. **Task queue** — heartbeat `tasks.md` (Open and In Progress items)
+3. **Git state** — `git status`, recent commits, open PRs/branches
+4. **TodoWrite** — any existing todo list from a prior session
+5. **Time budget** — ask if not stated (15min / 1hr / half-day / open-ended)
+
+## Output
+
+Present a short session plan:
+
+```
+## Session Plan — <date>
+
+**Time budget:** <duration>
+**Context:** <1-sentence summary of current state from memory>
+
+### Proposed tasks (in priority order)
+1. <task> — <why now, estimated effort>
+2. <task> — <why now, estimated effort>
+3. <task> — <stretch goal if time permits>
+
+### Not today
+- <task> — <why deferred>
+
+### Blockers / questions
+- <anything that needs human input before starting>
+```
+
+## Rules
+
+- **3 tasks max** for the main plan. A focused session beats a scattered one.
+- **Prioritize:** unfinished in-progress work > blocked items with new info > highest-leverage open task > recurring maintenance.
+- **Be concrete.** "Fix the flaky test in auth.py" not "work on testing."
+- **Mention dependencies.** If task 2 depends on task 1, say so.
+- **Adapt to time.** 15-minute session = 1 task. Half-day = 2-3 tasks with a stretch goal.
+- **Don't execute.** This skill produces a plan. The user (or ralph_loop) executes it.


### PR DESCRIPTION
## Summary
- New prompt-only skill: `session_planner` — reads memory, tasks, and git state to propose a focused work plan at session start
- Lighter than `ralph_loop` — produces a plan, doesn't execute it
- Added to Organize section (depends on hierarchical_memory + obsidian)
- Updated CHANGELOG (24→25 skills), README tables, Mermaid graph, and roadmap

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (172 tests)
- [ ] Manual: invoke `/session_planner` at start of a session and verify it reads memory + tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)