### PR TITLE
Add --reasoning-effort flag to ask_model.py

### DIFF
--- a/skills/discussion_partners/SKILL.md
+++ b/skills/discussion_partners/SKILL.md
@@ -83,6 +83,7 @@ variable to set. If the key exists but the call fails, common errors:
 ## Options
 
 - `--model` / `-m`: Full pydantic-ai model string (default: `openai:gpt-5.2`)
+- `--reasoning-effort` / `-r`: Reasoning effort level (`low`, `medium`, `high`, `xhigh`). Auto-detected if not set — defaults to `xhigh` for most models, `high` for mini models (which don't support `xhigh`). If you request `xhigh` on a mini model, it's automatically capped to `high` with a warning. Ignored for Google models (thinking is always enabled).
 - `--system` / `-s`: Optional system prompt override
 - `--list-models` / `-l`: List known model names, optionally filtered by prefix (e.g. `-l openai`, `-l anthropic`). Codex models appear under `openai:` but must be called with `openai-responses:` prefix.
 


### PR DESCRIPTION
## Summary
- Adds `--reasoning-effort` / `-r` flag to `ask_model.py` with choices: `low`, `medium`, `high`, `xhigh`
- Auto-detects default effort per model: `xhigh` for most OpenAI models, `high` for mini models (e.g. GPT-5-mini, codex-mini) that only support up to `high`
- If user explicitly requests `xhigh` on a mini model, auto-caps to `high` with a warning
- Maps effort levels to Anthropic equivalents (xhigh → max, etc.)
- Warns when `--reasoning-effort` is passed for Google models (which have no effort knob)
- Updates SKILL.md documentation with the new option

## Test plan
- [x] All 172 existing tests pass
- [x] Lint passes (ruff + pre-commit hooks)
- [x] CLI `--help` shows the new flag correctly
- [ ] Manual test: `ask_model.py -m openai:gpt-5-mini "test"` uses `high` by default
- [ ] Manual test: `ask_model.py -r high "test"` overrides default effort
- [ ] Manual test: `ask_model.py -m openai:gpt-5-mini -r xhigh "test"` caps to `high` with warning

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)