### PR TITLE
Configurable heartbeat repo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Skills that bundle Python code use [Click](https://click.palletsprojects.com/) f
 |----------|---------|-------------|
 | `CLAUDE_OBSIDIAN_DIR` | `~/claude/obsidian` | Vault root. All paths derive from it. |
 
+### Config Files
+
+| File | Default | Description |
+|------|---------|-------------|
+| `~/.claude/heartbeat-repos.conf` | `zachmayer/skills` | Repos for heartbeat to monitor. One `owner/repo` per line. See `skills/heartbeat/heartbeat-repos.conf.example`. |
+
 Rigid subdirectories (Claude creates these automatically):
 - `memory/` — hierarchical memory (daily logs, monthly summaries, `overall_memory.md`)
 - `knowledge_graph/` — durable topic notes, personal knowledge

--- a/skills/heartbeat/heartbeat-repos.conf.example
+++ b/skills/heartbeat/heartbeat-repos.conf.example
@@ -1,0 +1,4 @@
+# Heartbeat repo list — one owner/repo per line.
+# Copy to ~/.claude/heartbeat-repos.conf to activate.
+# Lines starting with # are ignored. Blank lines are ignored.
+zachmayer/skills

--- a/skills/heartbeat/scripts/heartbeat.sh
+++ b/skills/heartbeat/scripts/heartbeat.sh
@@ -19,8 +19,13 @@ MAX_TURNS=200
 MAX_BUDGET_USD=5
 
 # --- Repo registry ---
-# Space-separated list of owner/repo. Each cycle picks a random repo with issues.
-REPOS="zachmayer/skills"
+# Read from config file if present, otherwise use default.
+# Config file: one owner/repo per line, # comments allowed.
+REPOS_FILE="${HOME}/.claude/heartbeat-repos.conf"
+if [ -f "$REPOS_FILE" ]; then
+    REPOS=$(grep -v '^\s*#' "$REPOS_FILE" | grep -v '^\s*$' | tr '\n' ' ')
+fi
+REPOS="${REPOS:-zachmayer/skills}"
 
 # --- Issue filters (hardcoded for security — agent never constructs these) ---
 ISSUE_AUTHOR="zachmayer"


### PR DESCRIPTION
Fixes #75

## Summary
- Heartbeat reads repo list from `~/.claude/heartbeat-repos.conf` if present (one `owner/repo` per line, `#` comments allowed)
- Falls back to hardcoded `zachmayer/skills` when config file doesn't exist
- Ships `heartbeat-repos.conf.example` as a template
- Documents the config file in README

## What changed
- `heartbeat.sh`: Replace hardcoded `REPOS` with config file reader (4 lines of shell)
- `heartbeat-repos.conf.example`: Template with format documentation  
- `README.md`: Added Config Files section to Environment Variables

## Notes
- The `repo_dir()` case statement mentioned in the issue was already simplified to a one-liner in a prior PR
- No Python changes, so no new tests needed. Existing 172 tests pass. Shell syntax validated with `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)