### PR TITLE
Fix heartbeat in-progress label handling

### DIFF
--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -5,7 +5,7 @@ description: >
   work on GitHub Issues, create PRs, and maintain the obsidian vault. Use when
   the user wants autonomous periodic task processing or asks about running
   Claude on a schedule. Do NOT use for one-time tasks or interactive work.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git status), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *), Bash(git push *), Bash(git pull *), Bash(git fetch *), Bash(git -C *), Bash(git worktree *), Bash(gh pr create *), Bash(gh pr view *), Bash(gh pr list *), Bash(ls *), Bash(mkdir *), Bash(date *), Bash(uv run python *)
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git status), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *), Bash(git push *), Bash(git pull *), Bash(git fetch *), Bash(git -C *), Bash(git worktree *), Bash(gh pr create *), Bash(gh pr view *), Bash(gh pr list *), Bash(gh issue edit *), Bash(ls *), Bash(mkdir *), Bash(date *), Bash(uv run python *)
 ---
 
 You are the heartbeat agent. The runner (heartbeat.sh) discovers available issues, filters out claimed ones, and passes you a randomized list. Your job: pick an issue, claim it by creating a branch, implement the task, and create a PR.
@@ -27,6 +27,12 @@ git checkout -b heartbeat/issue-N
 ```
 
 If this fails, the issue is already claimed by another agent. **Pick a different issue and try again.**
+
+**Immediately after claiming, apply the `in-progress` label** so other agents skip this issue:
+
+```bash
+gh issue edit N --repo OWNER/REPO --add-label in-progress
+```
 
 Then implement the task, commit, push, and open a PR:
 


### PR DESCRIPTION
## Summary
- **Filter out in-progress issues**: `heartbeat.sh` now fetches the `labels` field from the GitHub API and excludes issues with the `in-progress` label during issue discovery, preventing multiple agents from picking the same issue.
- **Instruct agent to apply label**: `SKILL.md` now tells the agent to run `gh issue edit N --add-label in-progress` immediately after claiming a branch.
- **Grant permission**: Added `Bash(gh issue edit *)` to both the SKILL.md allowed-tools frontmatter and the `--allowedTools` flag in `heartbeat.sh`.

Fixes #82

## Test plan
- [x] All 172 tests pass
- [x] Lint clean
- [ ] Verify on next heartbeat cycle that the agent applies the `in-progress` label after claiming an issue
- [ ] Verify issues with `in-progress` label are excluded from the available issues list

🤖 Generated with [Claude Code](https://claude.com/claude-code)