### PR TITLE
Add women's game odds to fetch_odds.py

### DIFF
--- a/skills/march_madness/SKILL.md
+++ b/skills/march_madness/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: march_madness
+description: >
+  Fetch March Madness odds data from The Odds API. Use when you need to pull
+  NCAAB game odds, championship futures, or refresh odds data for the madness
+  model. Do NOT use for non-basketball sports or general sports betting.
+allowed-tools: Bash(uv run *)
+---
+
+Fetch NCAAB odds from The Odds API for March Madness modeling.
+
+## Prerequisites
+
+Set `ODDS_API_KEY` in `~/.zshrc`:
+
+```bash
+export ODDS_API_KEY="your-key"
+```
+
+## Commands
+
+```bash
+SKILL_DIR="skills/march_madness"
+
+# Men's game odds (h2h moneylines)
+uv run --directory $SKILL_DIR python scripts/fetch_odds.py game-odds --output game_odds.csv
+
+# Men's championship futures
+uv run --directory $SKILL_DIR python scripts/fetch_odds.py mens-futures --output mens_futures.csv
+
+# Women's game odds (may be inactive outside tournament season)
+uv run --directory $SKILL_DIR python scripts/fetch_odds.py womens-game-odds --output womens_game_odds.csv
+
+# Fetch all available odds
+uv run --directory $SKILL_DIR python scripts/fetch_odds.py fetch-all --output-dir output/
+```
+
+## Sport Keys
+
+| Key | Purpose |
+|-----|---------|
+| `basketball_ncaab` | Men's game odds (h2h, spreads, totals) |
+| `basketball_ncaab_championship_winner` | Men's championship futures |
+| `basketball_wncaab` | Women's game odds (may be inactive) |
+
+Women's championship futures do NOT exist in this API.
+
+## Credit Costs
+
+Each odds pull costs 1 credit per market per region. Daily pulls are cheap (~3 credits/day for all commands).

--- a/skills/march_madness/pyproject.toml
+++ b/skills/march_madness/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "march-madness"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+    "click>=8.1.0",
+    "requests>=2.31.0",
+]

--- a/skills/march_madness/scripts/fetch_odds.py
+++ b/skills/march_madness/scripts/fetch_odds.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Fetch NCAAB odds from The Odds API for March Madness modeling."""
+
+import csv
+import os
+from collections import defaultdict
+
+import click
+import requests
+
+API_BASE = "https://api.the-odds-api.com/v4"
+
+SPORT_NCAAB = "basketball_ncaab"
+SPORT_NCAAB_CHAMP = "basketball_ncaab_championship_winner"
+SPORT_WNCAAB = "basketball_wncaab"
+
+
+def _get_api_key() -> str:
+    """Get ODDS_API_KEY from environment or exit."""
+    key = os.environ.get("ODDS_API_KEY")
+    if not key:
+        click.echo("Error: ODDS_API_KEY not set.", err=True)
+        click.echo('Add to ~/.zshrc: export ODDS_API_KEY="your-key"', err=True)
+        raise SystemExit(1)
+    return key
+
+
+def _fetch_odds(sport: str, markets: str = "h2h", odds_format: str = "american") -> dict:
+    """Fetch odds from the API. Returns (data, headers) or exits on error."""
+    api_key = _get_api_key()
+    url = f"{API_BASE}/sports/{sport}/odds"
+    params = {
+        "apiKey": api_key,
+        "regions": "us",
+        "markets": markets,
+        "oddsFormat": odds_format,
+    }
+    resp = requests.get(url, params=params, timeout=30)
+
+    if resp.status_code == 422:
+        # Sport is inactive/invalid
+        return {"status": "inactive", "data": [], "headers": resp.headers}
+
+    if resp.status_code == 401:
+        click.echo("Error: Invalid ODDS_API_KEY.", err=True)
+        raise SystemExit(1)
+
+    if resp.status_code == 429:
+        click.echo("Error: Rate limited. Wait and retry.", err=True)
+        raise SystemExit(1)
+
+    if resp.status_code != 200:
+        click.echo(f"Error: API returned {resp.status_code}: {resp.text}", err=True)
+        raise SystemExit(1)
+
+    remaining = resp.headers.get("x-requests-remaining", "?")
+    used = resp.headers.get("x-requests-last", "?")
+    click.echo(f"Credits used: {used}, remaining: {remaining}", err=True)
+
+    return {"status": "ok", "data": resp.json(), "headers": resp.headers}
+
+
+def _parse_game_odds(events: list[dict]) -> list[dict]:
+    """Parse game odds events into rows: one per team with bookmaker columns."""
+    # Collect all bookmaker names
+    bookmaker_names: set[str] = set()
+    for event in events:
+        for bm in event.get("bookmakers", []):
+            bookmaker_names.add(bm["key"])
+
+    bookmakers_sorted = sorted(bookmaker_names)
+
+    # Build rows: one per team
+    rows: list[dict] = []
+    for event in events:
+        # Map bookmaker -> {team: price}
+        bm_prices: dict[str, dict[str, int]] = {}
+        for bm in event.get("bookmakers", []):
+            for market in bm.get("markets", []):
+                if market["key"] == "h2h":
+                    prices = {}
+                    for outcome in market.get("outcomes", []):
+                        prices[outcome["name"]] = outcome["price"]
+                    bm_prices[bm["key"]] = prices
+
+        for team_key in ("home_team", "away_team"):
+            team_name = event[team_key]
+            row: dict[str, str | int] = {"teamname": team_name}
+            for bm_key in bookmakers_sorted:
+                price = bm_prices.get(bm_key, {}).get(team_name, "")
+                row[bm_key] = price
+            rows.append(row)
+
+    return rows
+
+
+def _parse_futures(events: list[dict]) -> list[dict]:
+    """Parse championship futures into rows: one per team with bookmaker columns."""
+    bookmaker_names: set[str] = set()
+    # Futures typically have one event with outrights market
+    for event in events:
+        for bm in event.get("bookmakers", []):
+            bookmaker_names.add(bm["key"])
+
+    bookmakers_sorted = sorted(bookmaker_names)
+
+    # team -> {bookmaker: price}
+    team_odds: dict[str, dict[str, int]] = defaultdict(dict)
+    for event in events:
+        for bm in event.get("bookmakers", []):
+            for market in bm.get("markets", []):
+                for outcome in market.get("outcomes", []):
+                    team_odds[outcome["name"]][bm["key"]] = outcome["price"]
+
+    rows: list[dict] = []
+    for team_name in sorted(team_odds):
+        row: dict[str, str | int] = {"teamname": team_name}
+        for bm_key in bookmakers_sorted:
+            row[bm_key] = team_odds[team_name].get(bm_key, "")
+        rows.append(row)
+
+    return rows
+
+
+def _write_csv(rows: list[dict], output: str) -> None:
+    """Write rows to CSV file."""
+    if not rows:
+        click.echo("No data to write.", err=True)
+        return
+
+    fieldnames = list(rows[0].keys())
+    with open(output, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    click.echo(f"Wrote {len(rows)} rows to {output}")
+
+
+@click.group()
+def cli() -> None:
+    """Fetch NCAAB odds from The Odds API."""
+
+
+@cli.command("game-odds")
+@click.option("--output", "-o", default="game_odds.csv", help="Output CSV path")
+def game_odds(output: str) -> None:
+    """Fetch men's NCAAB game odds (h2h moneylines)."""
+    result = _fetch_odds(SPORT_NCAAB, markets="h2h")
+    if result["status"] != "ok":
+        click.echo("Men's game odds are not currently available.", err=True)
+        raise SystemExit(1)
+
+    rows = _parse_game_odds(result["data"])
+    _write_csv(rows, output)
+
+
+@cli.command("mens-futures")
+@click.option("--output", "-o", default="mens_futures.csv", help="Output CSV path")
+def mens_futures(output: str) -> None:
+    """Fetch men's NCAAB championship futures."""
+    result = _fetch_odds(SPORT_NCAAB_CHAMP, markets="outrights")
+    if result["status"] != "ok":
+        click.echo("Men's championship futures are not currently available.", err=True)
+        raise SystemExit(1)
+
+    rows = _parse_futures(result["data"])
+    _write_csv(rows, output)
+
+
+@cli.command("womens-game-odds")
+@click.option("--output", "-o", default="womens_game_odds.csv", help="Output CSV path")
+def womens_game_odds(output: str) -> None:
+    """Fetch women's NCAAB game odds (h2h moneylines).
+
+    This sport key may be inactive outside tournament season.
+    """
+    result = _fetch_odds(SPORT_WNCAAB, markets="h2h")
+    if result["status"] != "ok":
+        click.echo(
+            "Women's game odds (basketball_wncaab) are not currently active. "
+            "This is expected outside tournament season.",
+            err=True,
+        )
+        return
+
+    rows = _parse_game_odds(result["data"])
+    _write_csv(rows, output)
+
+
+@cli.command("fetch-all")
+@click.option("--output-dir", "-d", default=".", help="Output directory for CSV files")
+def fetch_all(output_dir: str) -> None:
+    """Fetch all available odds (mens game, mens futures, womens game)."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Men's game odds
+    click.echo("--- Men's game odds ---", err=True)
+    result = _fetch_odds(SPORT_NCAAB, markets="h2h")
+    if result["status"] == "ok":
+        rows = _parse_game_odds(result["data"])
+        _write_csv(rows, os.path.join(output_dir, "game_odds.csv"))
+    else:
+        click.echo("Men's game odds not available, skipping.", err=True)
+
+    # Men's futures
+    click.echo("--- Men's championship futures ---", err=True)
+    result = _fetch_odds(SPORT_NCAAB_CHAMP, markets="outrights")
+    if result["status"] == "ok":
+        rows = _parse_futures(result["data"])
+        _write_csv(rows, os.path.join(output_dir, "mens_futures.csv"))
+    else:
+        click.echo("Men's futures not available, skipping.", err=True)
+
+    # Women's game odds (non-fatal if inactive)
+    click.echo("--- Women's game odds ---", err=True)
+    result = _fetch_odds(SPORT_WNCAAB, markets="h2h")
+    if result["status"] == "ok":
+        rows = _parse_game_odds(result["data"])
+        _write_csv(rows, os.path.join(output_dir, "womens_game_odds.csv"))
+    else:
+        click.echo(
+            "Women's game odds (basketball_wncaab) not active, skipping. "
+            "Expected outside tournament season.",
+            err=True,
+        )
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/unit/test_fetch_odds.py
+++ b/tests/unit/test_fetch_odds.py
@@ -1,0 +1,364 @@
+"""Tests for the march_madness fetch_odds.py CLI."""
+
+import csv
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+# Import fetch_odds.py from the skill directory
+_spec = importlib.util.spec_from_file_location(
+    "fetch_odds",
+    Path(__file__).resolve().parents[2] / "skills" / "march_madness" / "scripts" / "fetch_odds.py",
+)
+assert _spec is not None and _spec.loader is not None
+fetch_odds = importlib.util.module_from_spec(_spec)
+sys.modules["fetch_odds"] = fetch_odds
+_spec.loader.exec_module(fetch_odds)
+
+
+# --- Fixtures ---
+
+SAMPLE_GAME_ODDS_RESPONSE = [
+    {
+        "id": "event1",
+        "sport_key": "basketball_ncaab",
+        "home_team": "Duke Blue Devils",
+        "away_team": "North Carolina Tar Heels",
+        "bookmakers": [
+            {
+                "key": "draftkings",
+                "title": "DraftKings",
+                "markets": [
+                    {
+                        "key": "h2h",
+                        "outcomes": [
+                            {"name": "Duke Blue Devils", "price": -150},
+                            {"name": "North Carolina Tar Heels", "price": 130},
+                        ],
+                    }
+                ],
+            },
+            {
+                "key": "fanduel",
+                "title": "FanDuel",
+                "markets": [
+                    {
+                        "key": "h2h",
+                        "outcomes": [
+                            {"name": "Duke Blue Devils", "price": -145},
+                            {"name": "North Carolina Tar Heels", "price": 125},
+                        ],
+                    }
+                ],
+            },
+        ],
+    },
+    {
+        "id": "event2",
+        "sport_key": "basketball_ncaab",
+        "home_team": "Kansas Jayhawks",
+        "away_team": "Kentucky Wildcats",
+        "bookmakers": [
+            {
+                "key": "draftkings",
+                "title": "DraftKings",
+                "markets": [
+                    {
+                        "key": "h2h",
+                        "outcomes": [
+                            {"name": "Kansas Jayhawks", "price": -200},
+                            {"name": "Kentucky Wildcats", "price": 170},
+                        ],
+                    }
+                ],
+            },
+        ],
+    },
+]
+
+SAMPLE_FUTURES_RESPONSE = [
+    {
+        "id": "futures1",
+        "sport_key": "basketball_ncaab_championship_winner",
+        "bookmakers": [
+            {
+                "key": "draftkings",
+                "title": "DraftKings",
+                "markets": [
+                    {
+                        "key": "outrights",
+                        "outcomes": [
+                            {"name": "Duke Blue Devils", "price": 400},
+                            {"name": "Kansas Jayhawks", "price": 600},
+                            {"name": "Auburn Tigers", "price": 800},
+                        ],
+                    }
+                ],
+            },
+            {
+                "key": "fanduel",
+                "title": "FanDuel",
+                "markets": [
+                    {
+                        "key": "outrights",
+                        "outcomes": [
+                            {"name": "Duke Blue Devils", "price": 450},
+                            {"name": "Kansas Jayhawks", "price": 550},
+                        ],
+                    }
+                ],
+            },
+        ],
+    },
+]
+
+
+def _mock_response(status_code: int = 200, data: list | None = None) -> MagicMock:
+    """Create a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = {
+        "x-requests-remaining": "99900",
+        "x-requests-last": "1",
+    }
+    resp.json.return_value = data or []
+    resp.text = json.dumps(data or [])
+    return resp
+
+
+# --- Tests for _parse_game_odds ---
+
+
+class TestParseGameOdds:
+    def test_basic_parsing(self) -> None:
+        rows = fetch_odds._parse_game_odds(SAMPLE_GAME_ODDS_RESPONSE)
+        assert len(rows) == 4  # 2 events x 2 teams each
+
+    def test_team_names(self) -> None:
+        rows = fetch_odds._parse_game_odds(SAMPLE_GAME_ODDS_RESPONSE)
+        names = [r["teamname"] for r in rows]
+        assert "Duke Blue Devils" in names
+        assert "North Carolina Tar Heels" in names
+        assert "Kansas Jayhawks" in names
+        assert "Kentucky Wildcats" in names
+
+    def test_bookmaker_columns(self) -> None:
+        rows = fetch_odds._parse_game_odds(SAMPLE_GAME_ODDS_RESPONSE)
+        duke = next(r for r in rows if r["teamname"] == "Duke Blue Devils")
+        assert duke["draftkings"] == -150
+        assert duke["fanduel"] == -145
+
+    def test_missing_bookmaker_is_empty(self) -> None:
+        rows = fetch_odds._parse_game_odds(SAMPLE_GAME_ODDS_RESPONSE)
+        # Kentucky only has draftkings, not fanduel
+        kentucky = next(r for r in rows if r["teamname"] == "Kentucky Wildcats")
+        assert kentucky["draftkings"] == 170
+        assert kentucky["fanduel"] == ""
+
+    def test_empty_events(self) -> None:
+        rows = fetch_odds._parse_game_odds([])
+        assert rows == []
+
+
+# --- Tests for _parse_futures ---
+
+
+class TestParseFutures:
+    def test_basic_parsing(self) -> None:
+        rows = fetch_odds._parse_futures(SAMPLE_FUTURES_RESPONSE)
+        assert len(rows) == 3  # Duke, Kansas, Auburn
+
+    def test_team_names_sorted(self) -> None:
+        rows = fetch_odds._parse_futures(SAMPLE_FUTURES_RESPONSE)
+        names = [r["teamname"] for r in rows]
+        assert names == sorted(names)
+
+    def test_bookmaker_columns(self) -> None:
+        rows = fetch_odds._parse_futures(SAMPLE_FUTURES_RESPONSE)
+        duke = next(r for r in rows if r["teamname"] == "Duke Blue Devils")
+        assert duke["draftkings"] == 400
+        assert duke["fanduel"] == 450
+
+    def test_missing_bookmaker_is_empty(self) -> None:
+        rows = fetch_odds._parse_futures(SAMPLE_FUTURES_RESPONSE)
+        auburn = next(r for r in rows if r["teamname"] == "Auburn Tigers")
+        assert auburn["draftkings"] == 800
+        assert auburn["fanduel"] == ""
+
+    def test_empty_events(self) -> None:
+        rows = fetch_odds._parse_futures([])
+        assert rows == []
+
+
+# --- Tests for CLI commands ---
+
+
+class TestCLIMissingApiKey:
+    def test_missing_odds_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ODDS_API_KEY", raising=False)
+        result = CliRunner().invoke(fetch_odds.cli, ["game-odds"])
+        assert result.exit_code != 0
+        assert "ODDS_API_KEY not set" in result.output
+
+
+class TestGameOddsCommand:
+    @patch("fetch_odds.requests.get")
+    def test_game_odds_success(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+        mock_get.return_value = _mock_response(200, SAMPLE_GAME_ODDS_RESPONSE)
+
+        output = str(tmp_path / "game_odds.csv")
+        result = CliRunner().invoke(fetch_odds.cli, ["game-odds", "--output", output])
+
+        assert result.exit_code == 0
+        assert "4 rows" in result.output
+        assert Path(output).exists()
+
+        # Verify CSV content
+        with open(output) as f:
+            reader = list(csv.DictReader(f))
+        assert len(reader) == 4
+        assert "teamname" in reader[0]
+        assert "draftkings" in reader[0]
+
+    @patch("fetch_odds.requests.get")
+    def test_game_odds_inactive(self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+        mock_get.return_value = _mock_response(422)
+
+        result = CliRunner().invoke(fetch_odds.cli, ["game-odds"])
+        assert result.exit_code != 0
+
+
+class TestMensFuturesCommand:
+    @patch("fetch_odds.requests.get")
+    def test_mens_futures_success(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+        mock_get.return_value = _mock_response(200, SAMPLE_FUTURES_RESPONSE)
+
+        output = str(tmp_path / "mens_futures.csv")
+        result = CliRunner().invoke(fetch_odds.cli, ["mens-futures", "--output", output])
+
+        assert result.exit_code == 0
+        assert "3 rows" in result.output
+        assert Path(output).exists()
+
+
+class TestWomensGameOddsCommand:
+    @patch("fetch_odds.requests.get")
+    def test_womens_game_odds_inactive_exits_clean(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When basketball_wncaab is inactive, should print message and exit 0."""
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+        mock_get.return_value = _mock_response(422)
+
+        result = CliRunner().invoke(fetch_odds.cli, ["womens-game-odds"])
+        assert result.exit_code == 0
+        assert "not currently active" in result.output
+
+    @patch("fetch_odds.requests.get")
+    def test_womens_game_odds_active(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+        mock_get.return_value = _mock_response(200, SAMPLE_GAME_ODDS_RESPONSE)
+
+        output = str(tmp_path / "womens_game_odds.csv")
+        result = CliRunner().invoke(fetch_odds.cli, ["womens-game-odds", "--output", output])
+
+        assert result.exit_code == 0
+        assert "4 rows" in result.output
+
+    @patch("fetch_odds.requests.get")
+    def test_womens_output_schema_matches_game_odds(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Women's game odds should have same schema as men's game odds."""
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+        mock_get.return_value = _mock_response(200, SAMPLE_GAME_ODDS_RESPONSE)
+
+        mens_output = str(tmp_path / "game_odds.csv")
+        womens_output = str(tmp_path / "womens_game_odds.csv")
+
+        CliRunner().invoke(fetch_odds.cli, ["game-odds", "--output", mens_output])
+        CliRunner().invoke(fetch_odds.cli, ["womens-game-odds", "--output", womens_output])
+
+        with open(mens_output) as f:
+            mens_headers = f.readline().strip()
+        with open(womens_output) as f:
+            womens_headers = f.readline().strip()
+
+        assert mens_headers == womens_headers
+
+
+class TestFetchAllCommand:
+    @patch("fetch_odds.requests.get")
+    def test_fetch_all_with_all_active(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+        mock_get.return_value = _mock_response(200, SAMPLE_GAME_ODDS_RESPONSE)
+
+        output_dir = str(tmp_path / "output")
+        result = CliRunner().invoke(fetch_odds.cli, ["fetch-all", "--output-dir", output_dir])
+
+        assert result.exit_code == 0
+        assert Path(output_dir, "game_odds.csv").exists()
+        assert Path(output_dir, "mens_futures.csv").exists()
+        assert Path(output_dir, "womens_game_odds.csv").exists()
+
+    @patch("fetch_odds.requests.get")
+    def test_fetch_all_womens_inactive_nonfatal(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """fetch-all should succeed even if womens odds are inactive."""
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+
+        def side_effect(*args: object, **kwargs: object) -> MagicMock:
+            url = args[0] if args else kwargs.get("url", "")
+            assert isinstance(url, str)
+            if "wncaab" in url:
+                return _mock_response(422)
+            return _mock_response(200, SAMPLE_GAME_ODDS_RESPONSE)
+
+        mock_get.side_effect = side_effect
+
+        output_dir = str(tmp_path / "output")
+        result = CliRunner().invoke(fetch_odds.cli, ["fetch-all", "--output-dir", output_dir])
+
+        assert result.exit_code == 0
+        assert Path(output_dir, "game_odds.csv").exists()
+        assert Path(output_dir, "mens_futures.csv").exists()
+        # womens file should NOT exist since sport was inactive
+        assert not Path(output_dir, "womens_game_odds.csv").exists()
+
+
+class TestAPIErrorHandling:
+    @patch("fetch_odds.requests.get")
+    def test_401_invalid_key(self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ODDS_API_KEY", "bad-key")
+        mock_get.return_value = _mock_response(401)
+
+        result = CliRunner().invoke(fetch_odds.cli, ["game-odds"])
+        assert result.exit_code != 0
+        assert "Invalid ODDS_API_KEY" in result.output
+
+    @patch("fetch_odds.requests.get")
+    def test_429_rate_limited(self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+        mock_get.return_value = _mock_response(429)
+
+        result = CliRunner().invoke(fetch_odds.cli, ["game-odds"])
+        assert result.exit_code != 0
+        assert "Rate limited" in result.output


### PR DESCRIPTION
## Summary
- Creates the `march_madness` skill with `fetch_odds.py` CLI
- Adds `womens-game-odds` command using sport key `basketball_wncaab`
- Handles inactive sport gracefully (prints message, exits clean with code 0)
- Output schema matches `game_odds.csv` format (teamname + bookmaker columns)
- Updates `fetch-all` to try womens odds after mens (non-fatal if inactive)
- 21 unit tests in `tests/unit/test_fetch_odds.py`

## Commands
| Command | Sport Key | Description |
|---------|-----------|-------------|
| `game-odds` | `basketball_ncaab` | Men's h2h moneylines |
| `mens-futures` | `basketball_ncaab_championship_winner` | Championship futures |
| `womens-game-odds` | `basketball_wncaab` | Women's h2h (may be inactive) |
| `fetch-all` | all above | All odds, womens failure non-fatal |

## Test plan
- [x] All 21 new unit tests pass
- [x] All 228 total tests pass (including skill structure tests)
- [x] Lint clean (ruff check + ruff format)
- [x] `womens-game-odds` exits cleanly (code 0) when sport is inactive
- [x] `fetch-all` succeeds even when womens odds are inactive
- [x] Women's output schema matches men's game odds schema

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)