### PR TITLE
Add staleness detection for obsidian notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Skills are grouped by their role in the capture → organize → process pipelin
 
 | Skill | Type | Description |
 |-------|------|-------------|
-| [obsidian](skills/obsidian/) | Prompt | Read, write, search, and link notes in a git-backed Obsidian vault |
+| [obsidian](skills/obsidian/) | Python | Read, write, search, and link notes in a git-backed Obsidian vault. Auto-detects and refreshes stale notes. |
 | [heartbeat](skills/heartbeat/) | Shell | launchd-based autonomous agent: picks up GitHub Issues, creates PRs |
 | [private_repo](skills/private_repo/) | Prompt | Create or connect private GitHub repos for git-backed storage |
 | [daily_briefing](skills/daily_briefing/) | Prompt | Morning summary from memory, tasks, and vault |

--- a/skills/obsidian/scripts/check_staleness.py
+++ b/skills/obsidian/scripts/check_staleness.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Check obsidian knowledge graph notes for staleness and missing metadata."""
+
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import click
+
+OBSIDIAN_DIR = Path(
+    os.environ.get("CLAUDE_OBSIDIAN_DIR", str(Path.home() / "claude" / "obsidian"))
+).expanduser()
+KNOWLEDGE_DIR = OBSIDIAN_DIR / "knowledge_graph"
+
+# Matches "Source: <value>" line (case-insensitive)
+SOURCE_RE = re.compile(r"^Source:\s*(.+)$", re.MULTILINE | re.IGNORECASE)
+# Matches "Date: <YYYY-MM-DD>" line (case-insensitive)
+DATE_RE = re.compile(r"^Date:\s*(\d{4}-\d{2}-\d{2})\s*$", re.MULTILINE | re.IGNORECASE)
+# Matches http/https URLs
+URL_RE = re.compile(r"^https?://\S+$")
+
+DEFAULT_STALE_DAYS = 90
+
+
+@dataclass
+class NoteMetadata:
+    """Parsed metadata from a single obsidian note."""
+
+    path: Path
+    source: str | None
+    date: str | None
+    has_url: bool
+
+    @property
+    def missing_date(self) -> bool:
+        return self.date is None
+
+    @property
+    def missing_source(self) -> bool:
+        return self.source is None
+
+    def days_old(self, now: datetime | None = None) -> int | None:
+        """Days since the note's Date field. None if no date."""
+        if self.date is None:
+            return None
+        if now is None:
+            now = datetime.now()
+        try:
+            note_date = datetime.strptime(self.date, "%Y-%m-%d")
+            return (now - note_date).days
+        except ValueError:
+            return None
+
+    def is_stale(
+        self, threshold_days: int = DEFAULT_STALE_DAYS, now: datetime | None = None
+    ) -> bool:
+        """True if the note has a fetchable URL and is older than threshold_days."""
+        if not self.has_url:
+            return False
+        days = self.days_old(now)
+        if days is None:
+            return False
+        return days > threshold_days
+
+
+def parse_note(path: Path) -> NoteMetadata:
+    """Parse Source and Date metadata from a note file."""
+    content = path.read_text(errors="replace")
+
+    source_match = SOURCE_RE.search(content)
+    date_match = DATE_RE.search(content)
+
+    source = source_match.group(1).strip() if source_match else None
+    date = date_match.group(1) if date_match else None
+    has_url = bool(source and URL_RE.match(source))
+
+    return NoteMetadata(path=path, source=source, date=date, has_url=has_url)
+
+
+def scan_vault(vault_dir: Path | None = None) -> list[NoteMetadata]:
+    """Scan all .md files in the knowledge graph and parse metadata."""
+    root = vault_dir or KNOWLEDGE_DIR
+    if not root.is_dir():
+        return []
+    notes = []
+    for md in sorted(root.rglob("*.md")):
+        notes.append(parse_note(md))
+    return notes
+
+
+@click.group()
+def cli() -> None:
+    """Obsidian knowledge graph staleness checker."""
+
+
+@cli.command()
+@click.argument("file_path")
+@click.option("--days", default=DEFAULT_STALE_DAYS, help="Staleness threshold in days.")
+def check(file_path: str, days: int) -> None:
+    """Check a single note for staleness.
+
+    Outputs a structured report: metadata present, age, stale status.
+    Exit code 0 = fresh or no URL, 1 = stale and should be refreshed.
+    """
+    path = Path(file_path).expanduser()
+    if not path.exists():
+        raise click.ClickException(f"File not found: {path}")
+
+    note = parse_note(path)
+    now = datetime.now()
+    age = note.days_old(now)
+    stale = note.is_stale(days, now)
+
+    click.echo(f"File: {note.path.name}")
+    click.echo(f"Source: {note.source or '(missing)'}")
+    click.echo(f"Date: {note.date or '(missing)'}")
+    click.echo(f"Has URL: {note.has_url}")
+    click.echo(f"Age: {age if age is not None else '(unknown)'} days")
+    click.echo(f"Stale: {stale} (threshold: {days} days)")
+
+    if stale:
+        click.echo(f"\nREFRESH RECOMMENDED: Re-fetch {note.source} and update this note.")
+        raise SystemExit(1)
+
+
+@cli.command()
+@click.option("--days", default=DEFAULT_STALE_DAYS, help="Staleness threshold in days.")
+@click.option(
+    "--vault-dir",
+    default=None,
+    help="Override vault directory (default: $CLAUDE_OBSIDIAN_DIR/knowledge_graph).",
+)
+def audit(days: int, vault_dir: str | None) -> None:
+    """Audit all knowledge graph notes for staleness and missing metadata.
+
+    Reports: stale notes, missing dates, missing sources.
+    """
+    root = Path(vault_dir) if vault_dir else None
+    notes = scan_vault(root)
+
+    if not notes:
+        click.echo("No notes found.")
+        return
+
+    stale = [n for n in notes if n.is_stale(days)]
+    missing_date = [n for n in notes if n.missing_date]
+    missing_source = [n for n in notes if n.missing_source]
+    with_url = [n for n in notes if n.has_url]
+
+    click.echo("## Obsidian Knowledge Graph Audit\n")
+    click.echo(f"Total notes: {len(notes)}")
+    click.echo(f"With Source URL: {len(with_url)}")
+    click.echo(f"Missing Date: {len(missing_date)}")
+    click.echo(f"Missing Source: {len(missing_source)}")
+    click.echo(f"Stale (>{days} days, has URL): {len(stale)}")
+
+    if stale:
+        click.echo("\n### Stale Notes (refresh recommended)\n")
+        for n in sorted(stale, key=lambda x: x.days_old() or 0, reverse=True):
+            rel = (
+                n.path.relative_to(root or KNOWLEDGE_DIR)
+                if (root or KNOWLEDGE_DIR) in n.path.parents
+                or n.path.parent == (root or KNOWLEDGE_DIR)
+                else n.path.name
+            )
+            click.echo(f"- {rel} ({n.days_old()} days old) — {n.source}")
+
+    if missing_date:
+        click.echo("\n### Missing Date\n")
+        for n in missing_date[:20]:
+            rel = (
+                n.path.relative_to(root or KNOWLEDGE_DIR)
+                if (root or KNOWLEDGE_DIR) in n.path.parents
+                or n.path.parent == (root or KNOWLEDGE_DIR)
+                else n.path.name
+            )
+            click.echo(f"- {rel}")
+        if len(missing_date) > 20:
+            click.echo(f"  ... and {len(missing_date) - 20} more")
+
+    if missing_source:
+        click.echo("\n### Missing Source\n")
+        for n in missing_source[:20]:
+            rel = (
+                n.path.relative_to(root or KNOWLEDGE_DIR)
+                if (root or KNOWLEDGE_DIR) in n.path.parents
+                or n.path.parent == (root or KNOWLEDGE_DIR)
+                else n.path.name
+            )
+            click.echo(f"- {rel}")
+        if len(missing_source) > 20:
+            click.echo(f"  ... and {len(missing_source) - 20} more")
+
+
+@cli.command(name="stale-urls")
+@click.option("--days", default=DEFAULT_STALE_DAYS, help="Staleness threshold in days.")
+@click.option(
+    "--vault-dir",
+    default=None,
+    help="Override vault directory (default: $CLAUDE_OBSIDIAN_DIR/knowledge_graph).",
+)
+def stale_urls(days: int, vault_dir: str | None) -> None:
+    """List just the stale notes with URLs, one per line.
+
+    Output format: <file_path>|<source_url>|<age_days>
+    Useful for piping into refresh workflows.
+    """
+    root = Path(vault_dir) if vault_dir else None
+    notes = scan_vault(root)
+    stale = [n for n in notes if n.is_stale(days)]
+
+    for n in sorted(stale, key=lambda x: x.days_old() or 0, reverse=True):
+        click.echo(f"{n.path}|{n.source}|{n.days_old()}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/unit/test_check_staleness.py
+++ b/tests/unit/test_check_staleness.py
@@ -1,0 +1,255 @@
+"""Tests for the obsidian check_staleness CLI."""
+
+import importlib.util
+import sys
+from datetime import datetime
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+# Import check_staleness.py from the skill directory
+_spec = importlib.util.spec_from_file_location(
+    "check_staleness",
+    Path(__file__).resolve().parents[2] / "skills" / "obsidian" / "scripts" / "check_staleness.py",
+)
+assert _spec is not None and _spec.loader is not None
+check_staleness = importlib.util.module_from_spec(_spec)
+sys.modules["check_staleness"] = check_staleness
+_spec.loader.exec_module(check_staleness)
+
+
+@pytest.fixture()
+def vault_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect KNOWLEDGE_DIR to a temp directory."""
+    monkeypatch.setattr(check_staleness, "KNOWLEDGE_DIR", tmp_path)
+    return tmp_path
+
+
+def _make_note(path: Path, source: str | None = None, date: str | None = None) -> None:
+    """Create a minimal obsidian note with optional Source/Date metadata."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"# {path.stem}", "#test"]
+    if source is not None:
+        lines.append(f"Source: {source}")
+    if date is not None:
+        lines.append(f"Date: {date}")
+    lines.append("\nSome content here.\n")
+    path.write_text("\n".join(lines))
+
+
+class TestParseNote:
+    def test_parses_source_and_date(self, tmp_path: Path) -> None:
+        p = tmp_path / "test.md"
+        _make_note(p, source="https://example.com", date="2026-01-15")
+        note = check_staleness.parse_note(p)
+        assert note.source == "https://example.com"
+        assert note.date == "2026-01-15"
+        assert note.has_url is True
+
+    def test_no_metadata(self, tmp_path: Path) -> None:
+        p = tmp_path / "bare.md"
+        p.write_text("# Bare note\n\nJust content.\n")
+        note = check_staleness.parse_note(p)
+        assert note.source is None
+        assert note.date is None
+        assert note.has_url is False
+
+    def test_non_url_source(self, tmp_path: Path) -> None:
+        p = tmp_path / "session.md"
+        _make_note(p, source="Claude Code session", date="2026-02-10")
+        note = check_staleness.parse_note(p)
+        assert note.source == "Claude Code session"
+        assert note.has_url is False
+
+    def test_source_original(self, tmp_path: Path) -> None:
+        p = tmp_path / "original.md"
+        _make_note(p, source="original", date="2026-02-10")
+        note = check_staleness.parse_note(p)
+        assert note.source == "original"
+        assert note.has_url is False
+
+    def test_http_source(self, tmp_path: Path) -> None:
+        p = tmp_path / "http.md"
+        _make_note(p, source="http://example.com/page", date="2026-02-10")
+        note = check_staleness.parse_note(p)
+        assert note.has_url is True
+
+    def test_case_insensitive_metadata(self, tmp_path: Path) -> None:
+        p = tmp_path / "case.md"
+        p.write_text("# Case test\nsource: https://example.com\ndate: 2026-01-01\n")
+        note = check_staleness.parse_note(p)
+        assert note.source == "https://example.com"
+        assert note.date == "2026-01-01"
+
+
+class TestNoteMetadata:
+    def test_missing_date(self, tmp_path: Path) -> None:
+        p = tmp_path / "nodate.md"
+        _make_note(p, source="https://example.com")
+        note = check_staleness.parse_note(p)
+        assert note.missing_date is True
+        assert note.days_old() is None
+
+    def test_missing_source(self, tmp_path: Path) -> None:
+        p = tmp_path / "nosource.md"
+        _make_note(p, date="2026-02-10")
+        note = check_staleness.parse_note(p)
+        assert note.missing_source is True
+
+    def test_days_old(self, tmp_path: Path) -> None:
+        p = tmp_path / "old.md"
+        _make_note(p, source="https://example.com", date="2026-01-01")
+        note = check_staleness.parse_note(p)
+        now = datetime(2026, 2, 14)
+        assert note.days_old(now) == 44
+
+    def test_is_stale_under_threshold(self, tmp_path: Path) -> None:
+        p = tmp_path / "fresh.md"
+        _make_note(p, source="https://example.com", date="2026-02-01")
+        note = check_staleness.parse_note(p)
+        now = datetime(2026, 2, 14)
+        assert note.is_stale(90, now) is False
+
+    def test_is_stale_over_threshold(self, tmp_path: Path) -> None:
+        p = tmp_path / "stale.md"
+        _make_note(p, source="https://example.com", date="2025-10-01")
+        note = check_staleness.parse_note(p)
+        now = datetime(2026, 2, 14)
+        assert note.is_stale(90, now) is True
+
+    def test_not_stale_without_url(self, tmp_path: Path) -> None:
+        p = tmp_path / "session.md"
+        _make_note(p, source="Claude Code session", date="2025-01-01")
+        note = check_staleness.parse_note(p)
+        now = datetime(2026, 2, 14)
+        assert note.is_stale(90, now) is False
+
+    def test_not_stale_without_date(self, tmp_path: Path) -> None:
+        p = tmp_path / "nodate.md"
+        _make_note(p, source="https://example.com")
+        note = check_staleness.parse_note(p)
+        assert note.is_stale(90) is False
+
+
+class TestScanVault:
+    def test_empty_vault(self, vault_dir: Path) -> None:
+        notes = check_staleness.scan_vault(vault_dir)
+        assert notes == []
+
+    def test_finds_all_notes(self, vault_dir: Path) -> None:
+        _make_note(vault_dir / "a.md", source="https://a.com", date="2026-02-01")
+        _make_note(vault_dir / "sub" / "b.md", source="https://b.com", date="2026-02-01")
+        _make_note(vault_dir / "c.md")
+        notes = check_staleness.scan_vault(vault_dir)
+        assert len(notes) == 3
+
+    def test_nonexistent_dir(self, tmp_path: Path) -> None:
+        notes = check_staleness.scan_vault(tmp_path / "nonexistent")
+        assert notes == []
+
+
+class TestCheckCommand:
+    def test_fresh_note(self, tmp_path: Path) -> None:
+        p = tmp_path / "fresh.md"
+        today = datetime.now().strftime("%Y-%m-%d")
+        _make_note(p, source="https://example.com", date=today)
+        result = CliRunner().invoke(check_staleness.cli, ["check", str(p)])
+        assert result.exit_code == 0
+        assert "Stale: False" in result.output
+        assert "Has URL: True" in result.output
+
+    def test_stale_note_exits_1(self, tmp_path: Path) -> None:
+        p = tmp_path / "stale.md"
+        old_date = (datetime.now() - timedelta(days=100)).strftime("%Y-%m-%d")
+        _make_note(p, source="https://example.com/docs", date=old_date)
+        result = CliRunner().invoke(check_staleness.cli, ["check", str(p)])
+        assert result.exit_code == 1
+        assert "Stale: True" in result.output
+        assert "REFRESH RECOMMENDED" in result.output
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        result = CliRunner().invoke(check_staleness.cli, ["check", str(tmp_path / "nope.md")])
+        assert result.exit_code != 0
+        assert "File not found" in result.output
+
+    def test_note_without_url(self, tmp_path: Path) -> None:
+        p = tmp_path / "session.md"
+        _make_note(p, source="Claude Code session", date="2025-01-01")
+        result = CliRunner().invoke(check_staleness.cli, ["check", str(p)])
+        assert result.exit_code == 0
+        assert "Stale: False" in result.output
+
+    def test_custom_threshold(self, tmp_path: Path) -> None:
+        p = tmp_path / "borderline.md"
+        date_50_ago = (datetime.now() - timedelta(days=50)).strftime("%Y-%m-%d")
+        _make_note(p, source="https://example.com", date=date_50_ago)
+        # Default 90 days: not stale
+        result = CliRunner().invoke(check_staleness.cli, ["check", str(p)])
+        assert result.exit_code == 0
+        # Custom 30 days: stale
+        result = CliRunner().invoke(check_staleness.cli, ["check", str(p), "--days", "30"])
+        assert result.exit_code == 1
+
+
+class TestAuditCommand:
+    def test_empty_vault(self, vault_dir: Path) -> None:
+        result = CliRunner().invoke(check_staleness.cli, ["audit", "--vault-dir", str(vault_dir)])
+        assert "No notes found" in result.output
+
+    def test_reports_counts(self, vault_dir: Path) -> None:
+        today = datetime.now().strftime("%Y-%m-%d")
+        _make_note(vault_dir / "with_url.md", source="https://example.com", date=today)
+        _make_note(vault_dir / "no_date.md", source="https://example.com")
+        _make_note(vault_dir / "no_source.md", date=today)
+        _make_note(vault_dir / "bare.md")
+        result = CliRunner().invoke(check_staleness.cli, ["audit", "--vault-dir", str(vault_dir)])
+        assert result.exit_code == 0
+        assert "Total notes: 4" in result.output
+        assert "With Source URL: 2" in result.output
+        assert "Missing Date: 2" in result.output
+        assert "Missing Source: 2" in result.output
+
+    def test_reports_stale(self, vault_dir: Path) -> None:
+        old_date = (datetime.now() - timedelta(days=100)).strftime("%Y-%m-%d")
+        _make_note(vault_dir / "stale.md", source="https://stale.example.com", date=old_date)
+        _make_note(
+            vault_dir / "fresh.md",
+            source="https://fresh.example.com",
+            date=datetime.now().strftime("%Y-%m-%d"),
+        )
+        result = CliRunner().invoke(check_staleness.cli, ["audit", "--vault-dir", str(vault_dir)])
+        assert "Stale (>90 days, has URL): 1" in result.output
+        assert "stale.md" in result.output
+        assert "stale.example.com" in result.output
+
+
+class TestStaleUrlsCommand:
+    def test_lists_stale_urls(self, vault_dir: Path) -> None:
+        old_date = (datetime.now() - timedelta(days=100)).strftime("%Y-%m-%d")
+        _make_note(vault_dir / "stale.md", source="https://stale.example.com", date=old_date)
+        _make_note(
+            vault_dir / "fresh.md",
+            source="https://fresh.example.com",
+            date=datetime.now().strftime("%Y-%m-%d"),
+        )
+        result = CliRunner().invoke(
+            check_staleness.cli, ["stale-urls", "--vault-dir", str(vault_dir)]
+        )
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert len(lines) == 1
+        parts = lines[0].split("|")
+        assert len(parts) == 3
+        assert "stale.md" in parts[0]
+        assert parts[1] == "https://stale.example.com"
+
+    def test_empty_when_all_fresh(self, vault_dir: Path) -> None:
+        today = datetime.now().strftime("%Y-%m-%d")
+        _make_note(vault_dir / "fresh.md", source="https://example.com", date=today)
+        result = CliRunner().invoke(
+            check_staleness.cli, ["stale-urls", "--vault-dir", str(vault_dir)]
+        )
+        assert result.exit_code == 0
+        assert result.output.strip() == ""


### PR DESCRIPTION
Fixes #91

## Summary
- New `check_staleness.py` CLI script in `skills/obsidian/scripts/` with three commands:
  - `check <file>`: Check a single note for staleness (exit 1 if stale, for scripted workflows)
  - `audit`: Vault-wide report showing stale notes, missing dates, missing sources
  - `stale-urls`: Machine-readable `path|url|age_days` output for piping into refresh loops
- Updated `SKILL.md` with staleness-aware read instructions: when reading a knowledge graph note, check its age first and re-fetch the source URL if >90 days old
- Added `Bash(uv run python *)` to obsidian skill's allowed-tools for script execution
- 26 new tests, all 228 passing, lint clean

## How it works
- Parses `Source:` and `Date:` metadata from note files
- Notes with an HTTP/HTTPS source URL older than 90 days (configurable) are flagged as stale
- Notes missing Date or Source are reported as broken metadata (distinct from staleness)
- Staleness threshold configurable via `--days` flag

## Current vault state (from audit)
- 137 knowledge graph notes, 77 with fetchable URLs
- 80 notes missing Date, 36 missing Source
- 0 currently stale (vault is <90 days old)

## Test plan
- [x] 26 unit tests covering parsing, staleness logic, and all CLI commands
- [x] Tested against actual vault (`uv run python scripts/check_staleness.py audit`)
- [x] Full test suite passes (228 tests)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)