### PR TITLE
Add capture inbox skill

### DIFF
--- a/skills/capture/SKILL.md
+++ b/skills/capture/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: capture_inbox
+name: capture
 description: >
   Smart routing for any input. Routes by scope + audience to the right
   destination: memory daily log (ephemeral), GitHub Issues with agent-task


### PR DESCRIPTION
Fixes #57

## Summary
- Adds `capture_inbox` skill — a smart routing layer that classifies any input by **durability** (ephemeral/durable/task/guidance), **scope** (personal/repo-specific/cross-project), and **audience** (agent/human/self)
- Routes to the right destination: memory daily log, obsidian knowledge_graph, GitHub Issues (with/without agent-task label), CLAUDE.md, or README.md
- Pure prompt skill — orchestrates existing `hierarchical_memory`, `obsidian`, and `gh` CLI without needing its own scripts
- Multi-route support: a single input can be filed to multiple destinations when appropriate
- CLAUDE.md/README.md edits are staged but not committed, so the user can review before committing

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (212 tests)
- [x] SKILL.md is 164 lines (under 500 limit)
- [ ] Manual test: invoke with "capture: always use uv run" and verify it routes to CLAUDE.md
- [ ] Manual test: invoke with "inbox: add retry logic" and verify it creates a GitHub Issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)