### PR TITLE
Add context compiler skill

### DIFF
--- a/skills/context_compiler/SKILL.md
+++ b/skills/context_compiler/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: context_compiler
+description: >
+  Assemble structured context docs from git diffs, files, memory, and obsidian notes.
+  WHEN: Preparing context for PR reviews, code discussions, or feeding structured
+  input to external models. WHEN NOT: For direct PR review (use pr_review), or when
+  you just need to read a single file.
+allowed-tools: Bash(uv run *), Bash(git diff *), Bash(git log *), Bash(git show *), Bash(gh pr *), Bash(gh api *), Read, Glob, Grep
+---
+
+Compile structured context documents from multiple sources into a single XML document. Generalizes the context assembly pattern from `pr_review` into a reusable tool.
+
+## Usage
+
+```bash
+uv run --directory SKILL_DIR python scripts/compile_context.py [OPTIONS]
+```
+
+All sources are optional — include only what you need. Output goes to stdout.
+
+## Options
+
+### Git sources
+- `--diff REF`: Include `git diff REF` output (e.g., `HEAD~3`, `main..HEAD`, a commit SHA)
+- `--log REF`: Include `git log REF` output (e.g., `-5`, `main..HEAD`)
+- `--pr NUMBER`: Include PR metadata and diff via `gh` (number, URL, or `owner/repo#N`)
+
+### File sources
+- `--file PATH`: Include a file's contents (repeatable)
+- `--glob PATTERN`: Include files matching a glob pattern (repeatable)
+
+### Memory / obsidian sources
+- `--memory PATH`: Include a memory file from the obsidian vault (repeatable)
+- `--obsidian-search QUERY`: Search obsidian vault and include matching notes (repeatable)
+- `--obsidian-dir DIR`: Obsidian vault directory (default: `$CLAUDE_OBSIDIAN_DIR` or `~/claude/obsidian`)
+
+### Output control
+- `--max-chars N`: Truncate total output at N chars (default: 100000)
+- `--format FORMAT`: Output format: `xml` (default) or `markdown`
+
+## Examples
+
+```bash
+# Context for a PR review (equivalent to what pr_review builds internally)
+uv run --directory SKILL_DIR python scripts/compile_context.py \
+  --pr 33 --file CLAUDE.md
+
+# Context from recent commits + architecture docs
+uv run --directory SKILL_DIR python scripts/compile_context.py \
+  --diff main..HEAD --log main..HEAD --file CLAUDE.md --file README.md
+
+# Context from obsidian notes
+uv run --directory SKILL_DIR python scripts/compile_context.py \
+  --memory memory/session_log.md --obsidian-search "authentication"
+
+# Combine everything for a thorough review
+uv run --directory SKILL_DIR python scripts/compile_context.py \
+  --pr 33 --file CLAUDE.md --memory memory/reminders.md --format xml
+```
+
+## Output Format
+
+### XML (default)
+
+```xml
+<context>
+  <source type="diff" ref="main..HEAD">
+    ... diff content ...
+  </source>
+  <source type="log" ref="main..HEAD">
+    ... log content ...
+  </source>
+  <source type="pr" ref="33">
+    <metadata>...</metadata>
+    <description>...</description>
+    <files>...</files>
+    <diff>...</diff>
+  </source>
+  <source type="file" path="CLAUDE.md">
+    ... file content ...
+  </source>
+  <source type="memory" path="memory/session_log.md">
+    ... note content ...
+  </source>
+  <source type="obsidian-search" query="authentication">
+    <result path="notes/auth.md">... content ...</result>
+  </source>
+</context>
+```
+
+### Markdown
+
+Sections are separated by headers with source metadata.

--- a/skills/context_compiler/scripts/compile_context.py
+++ b/skills/context_compiler/scripts/compile_context.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Compile structured context documents from multiple sources."""
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import click
+
+DEFAULT_MAX_CHARS = 100_000
+DEFAULT_OBSIDIAN_DIR = "~/claude/obsidian"
+
+
+def _run(cmd: list[str]) -> str:
+    """Run a command and return stdout. Raises SystemExit on failure."""
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        click.echo(f"Command failed: {' '.join(cmd)}\n{result.stderr.strip()}", err=True)
+        raise SystemExit(1)
+    return result.stdout
+
+
+def _truncate(text: str, max_chars: int, label: str) -> str:
+    """Truncate text with a warning if it exceeds max_chars."""
+    if len(text) <= max_chars:
+        return text
+    click.echo(f"{label}: {len(text):,} chars, truncating to {max_chars:,}", err=True)
+    return text[:max_chars] + f"\n\n[TRUNCATED — {label} too large]"
+
+
+def _escape_xml(text: str) -> str:
+    """Minimal XML escaping for attribute values."""
+    return (
+        text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+    )
+
+
+def _parse_pr_ref(ref: str) -> tuple[str | None, str]:
+    """Parse PR reference → (repo_or_none, number)."""
+    if "github.com" in ref:
+        parts = ref.rstrip("/").split("/")
+        try:
+            idx = parts.index("pull")
+            return f"{parts[idx - 2]}/{parts[idx - 1]}", parts[idx + 1]
+        except (ValueError, IndexError):
+            raise click.BadParameter(f"Can't parse PR URL: {ref}")
+    if "#" in ref and "/" in ref.split("#")[0]:
+        repo, number = ref.split("#", 1)
+        return repo, number
+    number = ref.lstrip("#")
+    if not number.isdigit():
+        raise click.BadParameter(f"Can't parse PR reference: {ref}")
+    return None, number
+
+
+def _fetch_pr(repo: str | None, number: str) -> tuple[dict[str, Any], str]:
+    """Fetch PR metadata and diff via gh CLI."""
+    repo_args = ["--repo", repo] if repo else []
+    meta_json = _run(
+        [
+            "gh",
+            "pr",
+            "view",
+            number,
+            *repo_args,
+            "--json",
+            "title,body,author,state,baseRefName,headRefName,files,url",
+        ]
+    )
+    meta = json.loads(meta_json)
+    diff = _run(["gh", "pr", "diff", number, *repo_args])
+    return meta, diff
+
+
+def _search_obsidian(query: str, obsidian_dir: Path) -> list[tuple[str, str]]:
+    """Search obsidian vault for notes matching query. Returns [(rel_path, content)]."""
+    results: list[tuple[str, str]] = []
+    query_lower = query.lower()
+    for md_file in sorted(obsidian_dir.rglob("*.md")):
+        if md_file.name.startswith("."):
+            continue
+        try:
+            content = md_file.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if query_lower in content.lower() or query_lower in md_file.stem.lower():
+            rel = str(md_file.relative_to(obsidian_dir))
+            results.append((rel, content))
+        if len(results) >= 5:
+            break
+    return results
+
+
+# --- Formatters ---
+
+
+def _xml_source(tag_type: str, content: str, **attrs: str) -> str:
+    """Build an XML source element."""
+    attr_str = " ".join(f'{k}="{_escape_xml(v)}"' for k, v in attrs.items())
+    return f'<source type="{tag_type}" {attr_str}>\n{content}\n</source>'
+
+
+def _md_source(heading: str, content: str) -> str:
+    """Build a markdown section."""
+    return f"## {heading}\n\n{content}"
+
+
+def _format_pr_xml(meta: dict[str, Any], diff: str, ref: str) -> str:
+    """Format PR data as XML."""
+    files = meta.get("files") or []
+    file_list = "\n".join(
+        f"  {f.get('path', '?')} (+{f.get('additions', 0)} -{f.get('deletions', 0)})" for f in files
+    )
+    inner = "\n".join(
+        [
+            "<metadata>",
+            f"  <title>{_escape_xml(meta.get('title', ''))}</title>",
+            f"  <author>{_escape_xml(meta.get('author', {}).get('login', '?'))}</author>",
+            f"  <url>{_escape_xml(meta.get('url', ''))}</url>",
+            f"  <base>{_escape_xml(meta.get('baseRefName', '?'))}</base>",
+            f"  <head>{_escape_xml(meta.get('headRefName', '?'))}</head>",
+            f"  <state>{_escape_xml(meta.get('state', '?'))}</state>",
+            "</metadata>",
+            "<description>",
+            meta.get("body") or "(no description)",
+            "</description>",
+            "<files>",
+            file_list or "(no files)",
+            "</files>",
+            "<diff>",
+            diff,
+            "</diff>",
+        ]
+    )
+    return _xml_source("pr", inner, ref=ref)
+
+
+def _format_pr_md(meta: dict[str, Any], diff: str, ref: str) -> str:
+    """Format PR data as markdown."""
+    files = meta.get("files") or []
+    file_list = "\n".join(
+        f"- {f.get('path', '?')} (+{f.get('additions', 0)} -{f.get('deletions', 0)})" for f in files
+    )
+    parts = [
+        f"**Title:** {meta.get('title', '')}",
+        f"**Author:** {meta.get('author', {}).get('login', '?')}",
+        f"**URL:** {meta.get('url', '')}",
+        f"**Base:** {meta.get('baseRefName', '?')} ← {meta.get('headRefName', '?')}",
+        "",
+        meta.get("body") or "(no description)",
+        "",
+        "### Files",
+        file_list or "(no files)",
+        "",
+        "### Diff",
+        "```diff",
+        diff,
+        "```",
+    ]
+    return _md_source(f"PR #{ref}", "\n".join(parts))
+
+
+class ContextCompiler:
+    """Assembles structured context from multiple sources."""
+
+    def __init__(
+        self, fmt: str = "xml", max_chars: int = DEFAULT_MAX_CHARS, obsidian_dir: Path | None = None
+    ) -> None:
+        self.fmt = fmt
+        self.max_chars = max_chars
+        self.obsidian_dir = obsidian_dir
+        self.sections: list[str] = []
+
+    def add_diff(self, ref: str) -> None:
+        """Add git diff output."""
+        diff = _run(["git", "diff", ref])
+        diff = _truncate(diff, self.max_chars // 2, f"diff {ref}")
+        if self.fmt == "xml":
+            self.sections.append(_xml_source("diff", diff, ref=ref))
+        else:
+            self.sections.append(_md_source(f"Git Diff: `{ref}`", f"```diff\n{diff}\n```"))
+
+    def add_log(self, ref: str) -> None:
+        """Add git log output."""
+        log = _run(["git", "log", "--oneline", ref])
+        if self.fmt == "xml":
+            self.sections.append(_xml_source("log", log, ref=ref))
+        else:
+            self.sections.append(_md_source(f"Git Log: `{ref}`", f"```\n{log}\n```"))
+
+    def add_pr(self, pr_ref: str) -> None:
+        """Add PR metadata and diff."""
+        repo, number = _parse_pr_ref(pr_ref)
+        meta, diff = _fetch_pr(repo, number)
+        diff = _truncate(diff, self.max_chars // 2, f"PR #{number} diff")
+        if self.fmt == "xml":
+            self.sections.append(_format_pr_xml(meta, diff, number))
+        else:
+            self.sections.append(_format_pr_md(meta, diff, number))
+
+    def add_file(self, path: str) -> None:
+        """Add a file's contents."""
+        try:
+            content = Path(path).read_text()
+        except (OSError, UnicodeDecodeError) as e:
+            click.echo(f"Warning: Can't read {path}: {e}", err=True)
+            return
+        content = _truncate(content, self.max_chars // 4, path)
+        if self.fmt == "xml":
+            self.sections.append(_xml_source("file", content, path=path))
+        else:
+            self.sections.append(_md_source(f"File: `{path}`", f"```\n{content}\n```"))
+
+    def add_glob(self, pattern: str) -> None:
+        """Add files matching a glob pattern."""
+        matches = sorted(Path(".").glob(pattern))
+        if not matches:
+            click.echo(f"Warning: No files match '{pattern}'", err=True)
+            return
+        for match in matches[:20]:  # cap at 20 files
+            self.add_file(str(match))
+
+    def add_memory(self, rel_path: str) -> None:
+        """Add a memory/obsidian file by relative path."""
+        if self.obsidian_dir is None:
+            click.echo("Warning: No obsidian dir configured, skipping memory", err=True)
+            return
+        full_path = self.obsidian_dir / rel_path
+        if not full_path.exists():
+            click.echo(f"Warning: Memory file not found: {full_path}", err=True)
+            return
+        content = full_path.read_text()
+        content = _truncate(content, self.max_chars // 4, rel_path)
+        if self.fmt == "xml":
+            self.sections.append(_xml_source("memory", content, path=rel_path))
+        else:
+            self.sections.append(_md_source(f"Memory: `{rel_path}`", content))
+
+    def add_obsidian_search(self, query: str) -> None:
+        """Search obsidian vault and add matching notes."""
+        if self.obsidian_dir is None:
+            click.echo("Warning: No obsidian dir configured, skipping search", err=True)
+            return
+        results = _search_obsidian(query, self.obsidian_dir)
+        if not results:
+            click.echo(f"Warning: No obsidian notes match '{query}'", err=True)
+            return
+        if self.fmt == "xml":
+            inner = "\n".join(
+                f'<result path="{_escape_xml(path)}">\n{content}\n</result>'
+                for path, content in results
+            )
+            self.sections.append(_xml_source("obsidian-search", inner, query=query))
+        else:
+            parts = []
+            for path, content in results:
+                parts.append(f"### `{path}`\n\n{content}")
+            self.sections.append(
+                _md_source(f"Obsidian Search: `{query}`", "\n\n---\n\n".join(parts))
+            )
+
+    def compile(self) -> str:
+        """Compile all sections into final output."""
+        if not self.sections:
+            click.echo("No sources added. Use --help for options.", err=True)
+            raise SystemExit(1)
+        if self.fmt == "xml":
+            body = "\n".join(self.sections)
+            output = f"<context>\n{body}\n</context>"
+        else:
+            output = "\n\n---\n\n".join(self.sections)
+        return _truncate(output, self.max_chars, "total output")
+
+
+@click.command()
+@click.option("--diff", "diffs", multiple=True, help="Git diff ref (e.g., main..HEAD)")
+@click.option("--log", "logs", multiple=True, help="Git log ref (e.g., main..HEAD, -5)")
+@click.option("--pr", "prs", multiple=True, help="PR number, URL, or owner/repo#N")
+@click.option("--file", "files", multiple=True, type=click.Path(), help="File to include")
+@click.option("--glob", "globs", multiple=True, help="Glob pattern for files")
+@click.option("--memory", "memories", multiple=True, help="Obsidian relative path")
+@click.option("--obsidian-search", "searches", multiple=True, help="Search query for obsidian")
+@click.option(
+    "--obsidian-dir",
+    envvar="CLAUDE_OBSIDIAN_DIR",
+    default=DEFAULT_OBSIDIAN_DIR,
+    help="Obsidian vault directory",
+)
+@click.option("--max-chars", default=DEFAULT_MAX_CHARS, show_default=True, help="Max output chars")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["xml", "markdown"]),
+    default="xml",
+    show_default=True,
+    help="Output format",
+)
+def main(
+    diffs: tuple[str, ...],
+    logs: tuple[str, ...],
+    prs: tuple[str, ...],
+    files: tuple[str, ...],
+    globs: tuple[str, ...],
+    memories: tuple[str, ...],
+    searches: tuple[str, ...],
+    obsidian_dir: str,
+    max_chars: int,
+    fmt: str,
+) -> None:
+    """Compile structured context from git diffs, files, memory, and obsidian notes."""
+    obs_path = Path(obsidian_dir).expanduser()
+    if not obs_path.exists():
+        obs_path = None  # type: ignore[assignment]
+
+    compiler = ContextCompiler(fmt=fmt, max_chars=max_chars, obsidian_dir=obs_path)
+
+    for ref in diffs:
+        compiler.add_diff(ref)
+    for ref in logs:
+        compiler.add_log(ref)
+    for pr_ref in prs:
+        compiler.add_pr(pr_ref)
+    for path in files:
+        compiler.add_file(path)
+    for pattern in globs:
+        compiler.add_glob(pattern)
+    for rel_path in memories:
+        compiler.add_memory(rel_path)
+    for query in searches:
+        compiler.add_obsidian_search(query)
+
+    click.echo(compiler.compile())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_compile_context.py
+++ b/tests/unit/test_compile_context.py
@@ -1,0 +1,275 @@
+"""Tests for the context_compiler compile_context.py CLI."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+# Import compile_context.py from the skill directory
+_spec = importlib.util.spec_from_file_location(
+    "compile_context",
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "context_compiler"
+    / "scripts"
+    / "compile_context.py",
+)
+assert _spec is not None and _spec.loader is not None
+compile_context = importlib.util.module_from_spec(_spec)
+sys.modules["compile_context"] = compile_context
+_spec.loader.exec_module(compile_context)
+
+
+class TestParsePrRef:
+    """Test _parse_pr_ref PR reference parsing."""
+
+    def test_plain_number(self) -> None:
+        repo, number = compile_context._parse_pr_ref("33")
+        assert repo is None
+        assert number == "33"
+
+    def test_hash_number(self) -> None:
+        repo, number = compile_context._parse_pr_ref("#33")
+        assert repo is None
+        assert number == "33"
+
+    def test_repo_hash_number(self) -> None:
+        repo, number = compile_context._parse_pr_ref("owner/repo#33")
+        assert repo == "owner/repo"
+        assert number == "33"
+
+    def test_url(self) -> None:
+        repo, number = compile_context._parse_pr_ref("https://github.com/owner/repo/pull/33")
+        assert repo == "owner/repo"
+        assert number == "33"
+
+    def test_invalid_ref_raises(self) -> None:
+        with pytest.raises(click.BadParameter, match="Can't parse"):
+            compile_context._parse_pr_ref("not-a-ref")
+
+
+class TestTruncate:
+    """Test _truncate helper."""
+
+    def test_no_truncation_needed(self) -> None:
+        result = compile_context._truncate("short", 100, "test")
+        assert result == "short"
+
+    def test_truncation_applied(self) -> None:
+        result = compile_context._truncate("a" * 200, 50, "test")
+        assert len(result) < 200
+        assert "TRUNCATED" in result
+
+    def test_exact_boundary(self) -> None:
+        text = "x" * 100
+        result = compile_context._truncate(text, 100, "test")
+        assert result == text
+
+
+class TestEscapeXml:
+    """Test _escape_xml helper."""
+
+    def test_escapes_ampersand(self) -> None:
+        assert compile_context._escape_xml("a&b") == "a&amp;b"
+
+    def test_escapes_angle_brackets(self) -> None:
+        assert compile_context._escape_xml("<b>") == "&lt;b&gt;"
+
+    def test_escapes_quotes(self) -> None:
+        assert compile_context._escape_xml('"hi"') == "&quot;hi&quot;"
+
+    def test_no_escaping_needed(self) -> None:
+        assert compile_context._escape_xml("hello") == "hello"
+
+
+class TestContextCompiler:
+    """Test ContextCompiler class."""
+
+    def test_compile_no_sources_exits(self) -> None:
+        compiler = compile_context.ContextCompiler()
+        with pytest.raises(SystemExit):
+            compiler.compile()
+
+    def test_add_file(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("hello world")
+
+        compiler = compile_context.ContextCompiler(fmt="xml")
+        compiler.add_file(str(test_file))
+        result = compiler.compile()
+
+        assert "<context>" in result
+        assert "hello world" in result
+        assert 'type="file"' in result
+
+    def test_add_file_markdown(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("hello world")
+
+        compiler = compile_context.ContextCompiler(fmt="markdown")
+        compiler.add_file(str(test_file))
+        result = compiler.compile()
+
+        assert "## File:" in result
+        assert "hello world" in result
+
+    def test_add_file_missing(self) -> None:
+        compiler = compile_context.ContextCompiler()
+        compiler.add_file("/nonexistent/path/file.txt")
+        # Should not crash, just warn
+        assert len(compiler.sections) == 0
+
+    def test_add_memory(self, tmp_path: Path) -> None:
+        memory_file = tmp_path / "memory" / "test.md"
+        memory_file.parent.mkdir()
+        memory_file.write_text("# Session Notes\nDid stuff.")
+
+        compiler = compile_context.ContextCompiler(fmt="xml", obsidian_dir=tmp_path)
+        compiler.add_memory("memory/test.md")
+        result = compiler.compile()
+
+        assert "Session Notes" in result
+        assert 'type="memory"' in result
+
+    def test_add_memory_no_obsidian_dir(self) -> None:
+        compiler = compile_context.ContextCompiler(fmt="xml", obsidian_dir=None)
+        compiler.add_memory("test.md")
+        assert len(compiler.sections) == 0
+
+    def test_add_obsidian_search(self, tmp_path: Path) -> None:
+        note = tmp_path / "notes" / "auth.md"
+        note.parent.mkdir()
+        note.write_text("# Authentication\nUse OAuth2 for auth.")
+
+        compiler = compile_context.ContextCompiler(fmt="xml", obsidian_dir=tmp_path)
+        compiler.add_obsidian_search("authentication")
+        result = compiler.compile()
+
+        assert "OAuth2" in result
+        assert 'type="obsidian-search"' in result
+
+    def test_add_obsidian_search_no_results(self, tmp_path: Path) -> None:
+        compiler = compile_context.ContextCompiler(fmt="xml", obsidian_dir=tmp_path)
+        compiler.add_obsidian_search("nonexistent-query-xyz")
+        assert len(compiler.sections) == 0
+
+    def test_add_glob(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "a.txt").write_text("file a")
+        (tmp_path / "b.txt").write_text("file b")
+
+        compiler = compile_context.ContextCompiler(fmt="xml")
+        compiler.add_glob("*.txt")
+        result = compiler.compile()
+
+        assert "file a" in result
+        assert "file b" in result
+
+    def test_max_chars_truncation(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "big.txt"
+        test_file.write_text("x" * 10000)
+
+        compiler = compile_context.ContextCompiler(fmt="xml", max_chars=500)
+        compiler.add_file(str(test_file))
+        result = compiler.compile()
+
+        assert len(result) <= 600  # max_chars + overhead
+
+    def test_add_diff(self) -> None:
+        compiler = compile_context.ContextCompiler(fmt="xml")
+        with patch.object(compile_context, "_run", return_value="diff output here"):
+            compiler.add_diff("HEAD~1")
+        result = compiler.compile()
+        assert "diff output here" in result
+        assert 'type="diff"' in result
+
+    def test_add_log(self) -> None:
+        compiler = compile_context.ContextCompiler(fmt="xml")
+        with patch.object(compile_context, "_run", return_value="abc123 commit msg"):
+            compiler.add_log("-5")
+        result = compiler.compile()
+        assert "abc123 commit msg" in result
+        assert 'type="log"' in result
+
+
+class TestCLI:
+    """Test CLI invocation."""
+
+    def test_no_args_exits_with_error(self) -> None:
+        result = CliRunner().invoke(compile_context.main, [])
+        assert result.exit_code != 0
+
+    def test_file_arg(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("content here")
+
+        result = CliRunner().invoke(compile_context.main, ["--file", str(test_file)])
+        assert result.exit_code == 0
+        assert "content here" in result.output
+        assert "<context>" in result.output
+
+    def test_markdown_format(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("content here")
+
+        result = CliRunner().invoke(
+            compile_context.main, ["--file", str(test_file), "--format", "markdown"]
+        )
+        assert result.exit_code == 0
+        assert "## File:" in result.output
+        assert "<context>" not in result.output
+
+    def test_diff_with_mock(self) -> None:
+        with patch.object(compile_context, "_run", return_value="mock diff"):
+            result = CliRunner().invoke(compile_context.main, ["--diff", "HEAD~1"])
+        assert result.exit_code == 0
+        assert "mock diff" in result.output
+
+    def test_multiple_sources(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "a.txt"
+        f2 = tmp_path / "b.txt"
+        f1.write_text("file a")
+        f2.write_text("file b")
+
+        result = CliRunner().invoke(compile_context.main, ["--file", str(f1), "--file", str(f2)])
+        assert result.exit_code == 0
+        assert "file a" in result.output
+        assert "file b" in result.output
+
+
+class TestSearchObsidian:
+    """Test _search_obsidian helper."""
+
+    def test_finds_by_content(self, tmp_path: Path) -> None:
+        note = tmp_path / "test.md"
+        note.write_text("Some unique content about widgets")
+        results = compile_context._search_obsidian("widgets", tmp_path)
+        assert len(results) == 1
+        assert "widgets" in results[0][1]
+
+    def test_finds_by_filename(self, tmp_path: Path) -> None:
+        note = tmp_path / "widgets.md"
+        note.write_text("Nothing about the query in body")
+        results = compile_context._search_obsidian("widgets", tmp_path)
+        assert len(results) == 1
+
+    def test_case_insensitive(self, tmp_path: Path) -> None:
+        note = tmp_path / "test.md"
+        note.write_text("WIDGETS are great")
+        results = compile_context._search_obsidian("widgets", tmp_path)
+        assert len(results) == 1
+
+    def test_max_results_capped(self, tmp_path: Path) -> None:
+        for i in range(10):
+            (tmp_path / f"note{i}.md").write_text("common query term")
+        results = compile_context._search_obsidian("common", tmp_path)
+        assert len(results) <= 5
+
+    def test_no_results(self, tmp_path: Path) -> None:
+        (tmp_path / "note.md").write_text("something else entirely")
+        results = compile_context._search_obsidian("nonexistent", tmp_path)
+        assert len(results) == 0


### PR DESCRIPTION
Fixes #56

## Summary
- New `context_compiler` skill that assembles structured context documents from multiple sources (git diffs, files, obsidian notes, memory) into XML or markdown output
- Generalizes the `_build_context` pattern from `pr_review` into a standalone, reusable CLI tool
- Supports: `--diff`, `--log`, `--pr`, `--file`, `--glob`, `--memory`, `--obsidian-search` sources
- Output formats: XML (default, structured tags) or markdown
- 34 unit tests covering helpers, compiler class, CLI, and obsidian search

## Test plan
- [x] All 34 new unit tests pass
- [x] Full test suite (246 tests) passes
- [x] Ruff lint and format pass
- [ ] Manual: `uv run --directory skills/context_compiler python scripts/compile_context.py --file CLAUDE.md`
- [ ] Manual: `uv run --directory skills/context_compiler python scripts/compile_context.py --diff HEAD~1 --format markdown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)