### PR TITLE
Add prompt_report skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Skills are grouped by their role in the capture → organize → process pipelin
 | [llm_judge](skills/llm_judge/) | Prompt | LLM-as-judge evaluation for comparing outputs |
 | [pr_review](skills/pr_review/) | Python | External AI code review: fetch PR context via gh, send to GPT-5.2 |
 | [api_key_checker](skills/api_key_checker/) | Python | Verify AI provider API keys are configured and valid |
+| [prompt_report](skills/prompt_report/) | Python | Analyze prompt effectiveness: token budget, clarity, coverage gaps |
 | [skill_pruner](skills/skill_pruner/) | Prompt | Audit skills for overlap, bloat, and quality |
 
 ## Skill Graph
@@ -123,7 +124,7 @@ graph LR
     daily_briefing --> obsidian
 ```
 
-Standalone skills (no imports): `api_key_checker`, `concise_writing`, `data_science`, `forecast`, `gh_cli`, `pdf_to_markdown`, `pr_review`, `skill_pruner`, `skill_stealer`
+Standalone skills (no imports): `api_key_checker`, `concise_writing`, `data_science`, `forecast`, `gh_cli`, `pdf_to_markdown`, `pr_review`, `prompt_report`, `skill_pruner`, `skill_stealer`
 
 ## Install
 

--- a/skills/prompt_report/SKILL.md
+++ b/skills/prompt_report/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: prompt_report
+description: >
+  Analyze prompt effectiveness: token budget, clarity, coverage gaps. Use when
+  reviewing SKILL.md files, system prompts, or any prompt text for quality and
+  efficiency. Do NOT use for generating or editing prompts (use prompt_evolution).
+---
+
+Analyze one or more prompt files and produce a structured effectiveness report.
+
+## Quick Start
+
+```bash
+# Analyze a single skill
+uv run --directory SKILL_DIR python scripts/analyze_prompt.py skills/staff_engineer/SKILL.md
+
+# Analyze multiple files
+uv run --directory SKILL_DIR python scripts/analyze_prompt.py skills/*/SKILL.md
+
+# JSON output for programmatic use
+uv run --directory SKILL_DIR python scripts/analyze_prompt.py --format json skills/ultra_think/SKILL.md
+
+# Set a custom context window (default: 200000 tokens)
+uv run --directory SKILL_DIR python scripts/analyze_prompt.py --context-window 128000 skills/mental_models/SKILL.md
+```
+
+## What It Measures
+
+### 1. Token Budget
+- Approximate token count (chars/4 heuristic — close enough for analysis)
+- Percentage of context window consumed
+- Line count and word count
+
+### 2. Structure & Clarity
+- YAML frontmatter present with `name` and `description`
+- Description uses WHEN/WHEN NOT pattern
+- Under 500 lines (repo convention)
+- Has section headers (##)
+- Name matches directory name
+
+### 3. Content Analysis
+- **Signal lines**: Behavioral overrides, prohibitions, templates, procedures, scoring formulas
+- **Filler lines**: Examples, meta-commentary, integration notes, references
+- **Signal ratio**: signal lines / total non-blank lines
+- **Coverage flags**: Missing frontmatter fields, no procedural steps, no output format
+
+### 4. Recommendations
+- Compression candidates (>150 lines with low signal ratio)
+- Missing structural elements
+- Token budget warnings (>5% of context window)
+
+## Report Format
+
+```
+## Prompt Report: <filename>
+
+### Budget
+- Tokens: ~N (N.N% of context window)
+- Lines: N | Words: N
+
+### Structure
+- [PASS/FAIL] YAML frontmatter
+- [PASS/FAIL] WHEN/WHEN NOT description
+- [PASS/FAIL] Under 500 lines
+- [PASS/FAIL] Has section headers
+- [PASS/SKIP] Name matches directory
+
+### Content
+- Signal lines: N (NN%)
+- Filler lines: N (NN%)
+- Blank/structural: N
+
+### Recommendations
+- [actionable items]
+```
+
+## Interpreting Results
+
+- **Signal ratio >70%**: Tight, well-compressed prompt
+- **Signal ratio 40-70%**: Room for compression — check filler lines
+- **Signal ratio <40%**: Heavy candidate for compression (see skill_pruner)
+- **>5% context window**: Large prompt — ensure value justifies cost
+- **>10% context window**: Very large — strongly consider splitting or compressing

--- a/skills/prompt_report/scripts/analyze_prompt.py
+++ b/skills/prompt_report/scripts/analyze_prompt.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Analyze prompt files for token budget, clarity, and coverage gaps."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+
+import click
+import frontmatter
+
+# Patterns that indicate high-value "signal" content
+SIGNAL_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^\s*-\s+\*\*", re.IGNORECASE),  # bold list items (key terms)
+    re.compile(r"^\s*\d+\.\s+", re.IGNORECASE),  # numbered steps (procedure)
+    re.compile(r"\b(never|always|must|do not|don't|avoid|require|prohibit)\b", re.IGNORECASE),
+    re.compile(r"\b(WHEN|WHEN NOT|IF|THEN|ELSE)\b"),  # conditional logic (caps)
+    re.compile(r"```"),  # code blocks (templates/formats)
+    re.compile(r"\b(score|formula|ratio|threshold|weight)\b", re.IGNORECASE),
+    re.compile(r"^\s*\|.*\|.*\|", re.IGNORECASE),  # table rows
+]
+
+# Patterns that indicate lower-value "filler" content
+FILLER_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^\s*-\s+(e\.g\.|for example|for instance)", re.IGNORECASE),
+    re.compile(r"^\s*-\s+\(", re.IGNORECASE),  # parenthetical asides
+    re.compile(r"\b(note:|tip:|hint:|remember:)", re.IGNORECASE),
+    re.compile(r"^\s*<!--"),  # HTML comments
+    re.compile(r"\[.*\]\(https?://", re.IGNORECASE),  # markdown links
+    re.compile(r"^\s*>\s+", re.IGNORECASE),  # blockquotes (often meta-commentary)
+]
+
+
+@dataclass
+class StructureCheck:
+    """Result of a single structural check."""
+
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class PromptReport:
+    """Analysis report for a single prompt file."""
+
+    file_path: str
+    line_count: int = 0
+    word_count: int = 0
+    char_count: int = 0
+    token_estimate: int = 0
+    context_pct: float = 0.0
+    context_window: int = 200_000
+
+    structure_checks: list[StructureCheck] = field(default_factory=list)
+
+    signal_lines: int = 0
+    filler_lines: int = 0
+    blank_lines: int = 0
+    structural_lines: int = 0  # headers, frontmatter delimiters
+    total_content_lines: int = 0
+
+    recommendations: list[str] = field(default_factory=list)
+
+    @property
+    def signal_ratio(self) -> float:
+        if self.total_content_lines == 0:
+            return 0.0
+        return self.signal_lines / self.total_content_lines
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count using chars/4 heuristic."""
+    return len(text) // 4
+
+
+def _is_structural_line(line: str) -> bool:
+    """Check if a line is structural (headers, frontmatter delimiters)."""
+    stripped = line.strip()
+    if stripped.startswith("#"):
+        return True
+    if stripped == "---":
+        return True
+    return False
+
+
+def _classify_line(line: str) -> str:
+    """Classify a line as signal, filler, blank, or structural."""
+    stripped = line.strip()
+    if not stripped:
+        return "blank"
+    if _is_structural_line(line):
+        return "structural"
+    for pattern in SIGNAL_PATTERNS:
+        if pattern.search(line):
+            return "signal"
+    for pattern in FILLER_PATTERNS:
+        if pattern.search(line):
+            return "filler"
+    # Default: count as signal (content that doesn't match filler patterns
+    # is more likely useful than not)
+    return "signal"
+
+
+def _check_directory_name(file_path: Path, fm_name: str | None) -> StructureCheck:
+    """Check if frontmatter name matches directory name."""
+    parent = file_path.parent
+    if parent.name == "scripts":
+        parent = parent.parent
+    dir_name = parent.name
+    if fm_name is None:
+        return StructureCheck("Name matches directory", False, "no name in frontmatter")
+    if fm_name == dir_name:
+        return StructureCheck("Name matches directory", True)
+    return StructureCheck("Name matches directory", False, f"name={fm_name!r}, dir={dir_name!r}")
+
+
+def analyze_file(file_path: Path, context_window: int = 200_000) -> PromptReport:
+    """Analyze a single prompt file."""
+    text = file_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    report = PromptReport(
+        file_path=str(file_path),
+        line_count=len(lines),
+        word_count=len(text.split()),
+        char_count=len(text),
+        token_estimate=_estimate_tokens(text),
+        context_window=context_window,
+    )
+    report.context_pct = (
+        (report.token_estimate / context_window) * 100 if context_window > 0 else 0.0
+    )
+
+    # Parse frontmatter
+    fm_name: str | None = None
+    fm_desc: str | None = None
+    has_frontmatter = False
+    try:
+        post = frontmatter.loads(text)
+        fm_name = post.metadata.get("name")
+        fm_desc = post.metadata.get("description")
+        has_frontmatter = bool(post.metadata)
+    except Exception:
+        pass
+
+    # Structure checks
+    report.structure_checks.append(StructureCheck("YAML frontmatter", has_frontmatter))
+
+    has_when = False
+    if fm_desc:
+        desc_lower = fm_desc.lower()
+        has_when = "when" in desc_lower or "use when" in desc_lower
+    report.structure_checks.append(StructureCheck("WHEN/WHEN NOT description", has_when))
+
+    under_500 = len(lines) <= 500
+    report.structure_checks.append(
+        StructureCheck(
+            "Under 500 lines",
+            under_500,
+            f"{len(lines)} lines" if not under_500 else "",
+        )
+    )
+
+    has_headers = any(line.strip().startswith("#") for line in lines)
+    report.structure_checks.append(StructureCheck("Has section headers", has_headers))
+
+    # Only check name match if it looks like a SKILL.md in a skill directory
+    if file_path.name == "SKILL.md":
+        report.structure_checks.append(_check_directory_name(file_path, fm_name))
+
+    # Classify lines
+    for line in lines:
+        cls = _classify_line(line)
+        if cls == "signal":
+            report.signal_lines += 1
+        elif cls == "filler":
+            report.filler_lines += 1
+        elif cls == "blank":
+            report.blank_lines += 1
+        elif cls == "structural":
+            report.structural_lines += 1
+
+    report.total_content_lines = report.signal_lines + report.filler_lines
+
+    # Recommendations
+    if not has_frontmatter:
+        report.recommendations.append("Add YAML frontmatter with name and description")
+    elif not fm_name:
+        report.recommendations.append("Add 'name' field to frontmatter")
+    if not has_when and fm_desc:
+        report.recommendations.append("Add WHEN/WHEN NOT pattern to description")
+
+    if report.line_count > 500:
+        report.recommendations.append(
+            f"Over 500 lines ({report.line_count}). Consider splitting or compressing."
+        )
+    elif report.line_count > 150 and report.signal_ratio < 0.5:
+        report.recommendations.append(
+            f"Compression candidate: {report.line_count} lines with "
+            f"{report.signal_ratio:.0%} signal ratio"
+        )
+
+    if report.context_pct > 10:
+        report.recommendations.append(
+            f"Very large prompt ({report.context_pct:.1f}% of context). "
+            f"Strongly consider splitting or compressing."
+        )
+    elif report.context_pct > 5:
+        report.recommendations.append(
+            f"Large prompt ({report.context_pct:.1f}% of context). "
+            f"Ensure value justifies token cost."
+        )
+
+    if not has_headers:
+        report.recommendations.append("Add section headers for scannability")
+
+    has_numbered_steps = any(re.match(r"^\s*\d+\.\s+", line) for line in lines)
+    if not has_numbered_steps and report.line_count > 20:
+        report.recommendations.append(
+            "No numbered steps found. Consider adding procedural structure."
+        )
+
+    return report
+
+
+def _format_check(check: StructureCheck) -> str:
+    """Format a structure check as a line."""
+    status = "PASS" if check.passed else "FAIL"
+    detail = f" ({check.detail})" if check.detail else ""
+    return f"- [{status}] {check.name}{detail}"
+
+
+def format_text(report: PromptReport) -> str:
+    """Format a report as human-readable text."""
+    lines: list[str] = []
+    lines.append(f"## Prompt Report: {report.file_path}")
+    lines.append("")
+
+    lines.append("### Budget")
+    lines.append(
+        f"- Tokens: ~{report.token_estimate:,} ({report.context_pct:.1f}% of "
+        f"{report.context_window:,} context window)"
+    )
+    lines.append(f"- Lines: {report.line_count} | Words: {report.word_count:,}")
+    lines.append("")
+
+    lines.append("### Structure")
+    for check in report.structure_checks:
+        lines.append(_format_check(check))
+    lines.append("")
+
+    lines.append("### Content")
+    lines.append(f"- Signal lines: {report.signal_lines} ({report.signal_ratio:.0%})")
+    lines.append(f"- Filler lines: {report.filler_lines}")
+    lines.append(f"- Blank/structural: {report.blank_lines + report.structural_lines}")
+    lines.append("")
+
+    if report.recommendations:
+        lines.append("### Recommendations")
+        for rec in report.recommendations:
+            lines.append(f"- {rec}")
+    else:
+        lines.append("### Recommendations")
+        lines.append("- No issues found.")
+
+    return "\n".join(lines)
+
+
+def format_json(report: PromptReport) -> str:
+    """Format a report as JSON."""
+    d = asdict(report)
+    d["signal_ratio"] = report.signal_ratio
+    return json.dumps(d, indent=2)
+
+
+@click.command()
+@click.argument("files", nargs=-1, required=True, type=click.Path(exists=True))
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format.",
+)
+@click.option(
+    "--context-window",
+    type=int,
+    default=200_000,
+    help="Context window size for budget calculation.",
+)
+def main(files: tuple[str, ...], output_format: str, context_window: int) -> None:
+    """Analyze prompt files for token budget, clarity, and coverage gaps."""
+    reports: list[PromptReport] = []
+    for f in files:
+        path = Path(f)
+        if not path.is_file():
+            click.echo(f"Skipping {f}: not a file", err=True)
+            continue
+        reports.append(analyze_file(path, context_window))
+
+    if output_format == "json":
+        if len(reports) == 1:
+            click.echo(format_json(reports[0]))
+        else:
+            all_data = []
+            for r in reports:
+                d = asdict(r)
+                d["signal_ratio"] = r.signal_ratio
+                all_data.append(d)
+            click.echo(json.dumps(all_data, indent=2))
+    else:
+        for i, r in enumerate(reports):
+            if i > 0:
+                click.echo("\n---\n")
+            click.echo(format_text(r))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_analyze_prompt.py
+++ b/tests/unit/test_analyze_prompt.py
@@ -1,0 +1,438 @@
+"""Tests for the prompt_report analyze_prompt.py CLI."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from click.testing import CliRunner
+
+# Import analyze_prompt.py from the skill directory
+_spec = importlib.util.spec_from_file_location(
+    "analyze_prompt",
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "prompt_report"
+    / "scripts"
+    / "analyze_prompt.py",
+)
+assert _spec is not None and _spec.loader is not None
+analyze_prompt = importlib.util.module_from_spec(_spec)
+sys.modules["analyze_prompt"] = analyze_prompt
+_spec.loader.exec_module(analyze_prompt)
+
+
+class TestEstimateTokens:
+    """Test token estimation heuristic."""
+
+    def test_empty_string(self) -> None:
+        assert analyze_prompt._estimate_tokens("") == 0
+
+    def test_short_text(self) -> None:
+        # 12 chars -> 3 tokens
+        assert analyze_prompt._estimate_tokens("hello world!") == 3
+
+    def test_longer_text(self) -> None:
+        text = "a" * 400
+        assert analyze_prompt._estimate_tokens(text) == 100
+
+
+class TestClassifyLine:
+    """Test line classification logic."""
+
+    def test_blank_line(self) -> None:
+        assert analyze_prompt._classify_line("") == "blank"
+        assert analyze_prompt._classify_line("   ") == "blank"
+
+    def test_header_is_structural(self) -> None:
+        assert analyze_prompt._classify_line("## Section") == "structural"
+        assert analyze_prompt._classify_line("# Top") == "structural"
+
+    def test_frontmatter_delimiter(self) -> None:
+        assert analyze_prompt._classify_line("---") == "structural"
+
+    def test_numbered_step_is_signal(self) -> None:
+        assert analyze_prompt._classify_line("1. Do the thing") == "signal"
+        assert analyze_prompt._classify_line("  3. Another step") == "signal"
+
+    def test_bold_list_item_is_signal(self) -> None:
+        assert analyze_prompt._classify_line("- **Important**: details") == "signal"
+
+    def test_prohibition_is_signal(self) -> None:
+        assert analyze_prompt._classify_line("Never use eval()") == "signal"
+        assert analyze_prompt._classify_line("You must always verify") == "signal"
+        assert analyze_prompt._classify_line("Do not skip tests") == "signal"
+        assert analyze_prompt._classify_line("Avoid using globals") == "signal"
+
+    def test_table_row_is_signal(self) -> None:
+        assert analyze_prompt._classify_line("| col1 | col2 | col3 |") == "signal"
+
+    def test_code_fence_is_signal(self) -> None:
+        assert analyze_prompt._classify_line("```python") == "signal"
+        assert analyze_prompt._classify_line("```") == "signal"
+
+    def test_example_is_filler(self) -> None:
+        assert analyze_prompt._classify_line("- e.g. this is an example") == "filler"
+        assert analyze_prompt._classify_line("- For example, consider") == "filler"
+
+    def test_note_is_filler(self) -> None:
+        assert analyze_prompt._classify_line("Tip: remember to check") == "filler"
+
+    def test_link_is_filler(self) -> None:
+        assert analyze_prompt._classify_line("See [docs](https://example.com)") == "filler"
+
+    def test_blockquote_is_filler(self) -> None:
+        assert analyze_prompt._classify_line("> Some quoted text") == "filler"
+
+    def test_plain_text_defaults_to_signal(self) -> None:
+        assert analyze_prompt._classify_line("Use the tool to check results") == "signal"
+
+
+class TestIsStructuralLine:
+    """Test structural line detection."""
+
+    def test_header(self) -> None:
+        assert analyze_prompt._is_structural_line("## Header")
+
+    def test_frontmatter_delimiter(self) -> None:
+        assert analyze_prompt._is_structural_line("---")
+
+    def test_regular_text(self) -> None:
+        assert not analyze_prompt._is_structural_line("regular text")
+
+
+class TestCheckDirectoryName:
+    """Test directory name matching."""
+
+    def test_matching_name(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "my_skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.touch()
+        result = analyze_prompt._check_directory_name(skill_file, "my_skill")
+        assert result.passed
+
+    def test_mismatched_name(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "my_skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.touch()
+        result = analyze_prompt._check_directory_name(skill_file, "other_name")
+        assert not result.passed
+        assert "other_name" in result.detail
+
+    def test_no_name(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "my_skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.touch()
+        result = analyze_prompt._check_directory_name(skill_file, None)
+        assert not result.passed
+        assert "no name" in result.detail
+
+    def test_scripts_subdirectory(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "my_skill" / "scripts"
+        skill_dir.mkdir(parents=True)
+        script = skill_dir / "run.py"
+        script.touch()
+        result = analyze_prompt._check_directory_name(script, "my_skill")
+        assert result.passed
+
+
+class TestAnalyzeFile:
+    """Test full file analysis."""
+
+    def test_well_formed_skill(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "good_skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text(
+            dedent("""\
+            ---
+            name: good_skill
+            description: >
+              Use when testing. Do NOT use in production.
+            ---
+
+            ## Overview
+
+            1. Do step one
+            2. Do step two
+            3. Never skip step three
+
+            ## Output
+
+            ```
+            result: value
+            ```
+        """)
+        )
+        report = analyze_prompt.analyze_file(skill_file)
+        assert report.line_count > 0
+        assert report.token_estimate > 0
+        assert report.context_pct > 0
+        # All structure checks should pass
+        for check in report.structure_checks:
+            assert check.passed, f"{check.name} failed: {check.detail}"
+
+    def test_missing_frontmatter(self, tmp_path: Path) -> None:
+        f = tmp_path / "bare.md"
+        f.write_text("Just some text\nwith no frontmatter\n")
+        report = analyze_prompt.analyze_file(f)
+        fm_check = next(c for c in report.structure_checks if c.name == "YAML frontmatter")
+        assert not fm_check.passed
+        assert any("frontmatter" in r.lower() for r in report.recommendations)
+
+    def test_over_500_lines(self, tmp_path: Path) -> None:
+        f = tmp_path / "long.md"
+        lines = ["---", "name: long", "description: test", "---"] + [
+            f"Line {i}" for i in range(600)
+        ]
+        f.write_text("\n".join(lines))
+        report = analyze_prompt.analyze_file(f)
+        under_500 = next(c for c in report.structure_checks if c.name == "Under 500 lines")
+        assert not under_500.passed
+        assert any("500" in r for r in report.recommendations)
+
+    def test_no_headers(self, tmp_path: Path) -> None:
+        f = tmp_path / "flat.md"
+        f.write_text("---\nname: flat\ndescription: test when\n---\nJust text no headers\n" * 5)
+        report = analyze_prompt.analyze_file(f)
+        header_check = next(c for c in report.structure_checks if c.name == "Has section headers")
+        assert not header_check.passed
+        assert any("header" in r.lower() for r in report.recommendations)
+
+    def test_custom_context_window(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.md"
+        # 4000 chars -> ~1000 tokens -> 1% of 100k
+        f.write_text("x" * 4000)
+        report = analyze_prompt.analyze_file(f, context_window=100_000)
+        assert report.context_window == 100_000
+        assert report.context_pct == pytest.approx(1.0, abs=0.1)
+
+    def test_large_context_warning(self, tmp_path: Path) -> None:
+        f = tmp_path / "huge.md"
+        # ~6% of 10k context
+        f.write_text("x" * 2400)
+        report = analyze_prompt.analyze_file(f, context_window=10_000)
+        assert any("context" in r.lower() for r in report.recommendations)
+
+    def test_blank_and_structural_counting(self, tmp_path: Path) -> None:
+        f = tmp_path / "mixed.md"
+        f.write_text(
+            dedent("""\
+            ---
+            name: test
+            description: test when
+            ---
+
+            ## Section
+
+            Never do this.
+
+            > Some quote here.
+
+        """)
+        )
+        report = analyze_prompt.analyze_file(f)
+        assert report.blank_lines >= 3
+        assert report.structural_lines >= 3  # ---, ---, ##
+        assert report.signal_lines >= 1  # "Never do this"
+        assert report.filler_lines >= 1  # blockquote
+
+    def test_signal_ratio(self, tmp_path: Path) -> None:
+        f = tmp_path / "ratio.md"
+        f.write_text(
+            dedent("""\
+            Never do X
+            Always do Y
+            > quote filler
+            - e.g. example filler
+        """)
+        )
+        report = analyze_prompt.analyze_file(f)
+        assert report.signal_lines == 2
+        assert report.filler_lines == 2
+        assert report.signal_ratio == pytest.approx(0.5)
+
+    def test_no_numbered_steps_recommendation(self, tmp_path: Path) -> None:
+        f = tmp_path / "nosteps.md"
+        lines = ["---", "name: x", "description: when test", "---"]
+        lines += ["Some content line"] * 25
+        f.write_text("\n".join(lines))
+        report = analyze_prompt.analyze_file(f)
+        assert any("numbered steps" in r.lower() for r in report.recommendations)
+
+    def test_when_not_in_description(self, tmp_path: Path) -> None:
+        f = tmp_path / "notwhen.md"
+        f.write_text("---\nname: x\ndescription: just a plain description\n---\n")
+        report = analyze_prompt.analyze_file(f)
+        when_check = next(c for c in report.structure_checks if "WHEN" in c.name)
+        assert not when_check.passed
+
+    def test_skill_md_checks_dir_name(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "my_skill"
+        skill_dir.mkdir()
+        f = skill_dir / "SKILL.md"
+        f.write_text("---\nname: wrong_name\ndescription: when test\n---\n")
+        report = analyze_prompt.analyze_file(f)
+        name_check = next(
+            (c for c in report.structure_checks if "directory" in c.name.lower()),
+            None,
+        )
+        assert name_check is not None
+        assert not name_check.passed
+
+    def test_non_skill_md_skips_dir_check(self, tmp_path: Path) -> None:
+        f = tmp_path / "prompt.txt"
+        f.write_text("---\nname: x\ndescription: when\n---\n")
+        report = analyze_prompt.analyze_file(f)
+        name_checks = [c for c in report.structure_checks if "directory" in c.name.lower()]
+        assert len(name_checks) == 0
+
+
+class TestFormatText:
+    """Test text formatting."""
+
+    def test_contains_sections(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.md"
+        f.write_text("---\nname: x\ndescription: when\n---\n## H\n1. step\n")
+        report = analyze_prompt.analyze_file(f)
+        text = analyze_prompt.format_text(report)
+        assert "## Prompt Report:" in text
+        assert "### Budget" in text
+        assert "### Structure" in text
+        assert "### Content" in text
+        assert "### Recommendations" in text
+
+    def test_no_issues_message(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "clean"
+        skill_dir.mkdir()
+        f = skill_dir / "SKILL.md"
+        f.write_text("---\nname: clean\ndescription: Use when testing.\n---\n## H\n1. step\n")
+        report = analyze_prompt.analyze_file(f)
+        text = analyze_prompt.format_text(report)
+        assert "No issues found" in text
+
+
+class TestFormatJson:
+    """Test JSON formatting."""
+
+    def test_valid_json(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.md"
+        f.write_text("---\nname: x\ndescription: when\n---\n")
+        report = analyze_prompt.analyze_file(f)
+        output = analyze_prompt.format_json(report)
+        data = json.loads(output)
+        assert "file_path" in data
+        assert "token_estimate" in data
+        assert "signal_ratio" in data
+        assert "structure_checks" in data
+
+    def test_signal_ratio_in_json(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.md"
+        f.write_text("Never do this\nAlways do that\n")
+        report = analyze_prompt.analyze_file(f)
+        data = json.loads(analyze_prompt.format_json(report))
+        assert isinstance(data["signal_ratio"], float)
+
+
+class TestCLI:
+    """Test the Click CLI entry point."""
+
+    def test_single_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.md"
+        f.write_text("---\nname: x\ndescription: when\n---\n## H\n1. step\n")
+        runner = CliRunner()
+        result = runner.invoke(analyze_prompt.main, [str(f)])
+        assert result.exit_code == 0
+        assert "Prompt Report" in result.output
+
+    def test_multiple_files(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "a.md"
+        f2 = tmp_path / "b.md"
+        f1.write_text("---\nname: a\ndescription: when\n---\n")
+        f2.write_text("---\nname: b\ndescription: when\n---\n")
+        runner = CliRunner()
+        result = runner.invoke(analyze_prompt.main, [str(f1), str(f2)])
+        assert result.exit_code == 0
+        assert result.output.count("Prompt Report") == 2
+        assert "---" in result.output
+
+    def test_json_output(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.md"
+        f.write_text("---\nname: x\ndescription: when\n---\n")
+        runner = CliRunner()
+        result = runner.invoke(analyze_prompt.main, [str(f), "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "token_estimate" in data
+
+    def test_json_multiple_files(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "a.md"
+        f2 = tmp_path / "b.md"
+        f1.write_text("text a\n")
+        f2.write_text("text b\n")
+        runner = CliRunner()
+        result = runner.invoke(analyze_prompt.main, [str(f1), str(f2), "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+    def test_custom_context_window(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.md"
+        f.write_text("x" * 4000)
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_prompt.main, [str(f), "--context-window", "100000", "--format", "json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["context_window"] == 100000
+
+    def test_no_files_shows_error(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(analyze_prompt.main, [])
+        assert result.exit_code != 0
+
+    def test_nonexistent_file(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(analyze_prompt.main, ["/nonexistent/file.md"])
+        assert result.exit_code != 0
+
+
+class TestOnRealSkills:
+    """Smoke tests against actual skills in the repo."""
+
+    SKILLS_DIR = Path(__file__).resolve().parents[2] / "skills"
+
+    @pytest.mark.skipif(
+        not (
+            Path(__file__).resolve().parents[2] / "skills" / "staff_engineer" / "SKILL.md"
+        ).exists(),
+        reason="skills directory not available",
+    )
+    def test_staff_engineer(self) -> None:
+        f = self.SKILLS_DIR / "staff_engineer" / "SKILL.md"
+        report = analyze_prompt.analyze_file(f)
+        assert report.line_count > 0
+        assert report.token_estimate > 0
+        for check in report.structure_checks:
+            assert check.passed, f"{check.name} failed"
+
+    @pytest.mark.skipif(
+        not (
+            Path(__file__).resolve().parents[2] / "skills" / "prompt_report" / "SKILL.md"
+        ).exists(),
+        reason="skills directory not available",
+    )
+    def test_prompt_report_self(self) -> None:
+        """The prompt_report skill should pass its own analysis."""
+        f = self.SKILLS_DIR / "prompt_report" / "SKILL.md"
+        report = analyze_prompt.analyze_file(f)
+        assert report.line_count > 0
+        for check in report.structure_checks:
+            assert check.passed, f"{check.name} failed: {check.detail}"


### PR DESCRIPTION
## Summary

- New `prompt_report` skill that analyzes prompt files for effectiveness
- Python CLI (`analyze_prompt.py`) measures token budget, structural clarity, signal-vs-filler content ratio, and coverage gaps
- Supports single/multiple files, text/JSON output, configurable context window size
- 48 unit tests, 260 total passing, lint clean

## What it does

Analyzes any prompt file (SKILL.md or plain text) and produces a structured report:
- **Token budget**: approximate count and % of context window consumed
- **Structure checks**: YAML frontmatter, WHEN/WHEN NOT pattern, line count, headers, name-directory match
- **Content analysis**: classifies lines as signal (behavioral overrides, procedures, prohibitions) vs filler (examples, meta-commentary, links)
- **Recommendations**: compression candidates, missing elements, budget warnings

## Usage

```bash
# Single file
uv run --directory skills/prompt_report python scripts/analyze_prompt.py skills/staff_engineer/SKILL.md

# All skills
uv run --directory skills/prompt_report python scripts/analyze_prompt.py skills/*/SKILL.md

# JSON output
uv run --directory skills/prompt_report python scripts/analyze_prompt.py --format json skills/ultra_think/SKILL.md
```

Fixes #59

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>