### PR TITLE
Add voice_notes skill for audio transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Skills are grouped by their role in the capture → organize → process pipelin
 | [hierarchical_memory](skills/hierarchical_memory/) | Python | Quick notes aggregated into daily/monthly/overall summaries |
 | [web_grab](skills/web_grab/) | Python | Fetch URL content and save to obsidian — Playwright for JS SPAs |
 | [pdf_to_markdown](skills/pdf_to_markdown/) | Python | Convert PDFs to clean markdown for vault storage |
+| [voice_notes](skills/voice_notes/) | Python | Transcribe audio files to text via OpenAI Whisper API |
 | [remember_session](skills/remember_session/) | Prompt | Save session learnings to memory and obsidian |
 | [skill_stealer](skills/skill_stealer/) | Prompt | Extract reusable skills from URLs into SKILL.md |
 
@@ -116,6 +117,8 @@ graph LR
     obsidian --> private_repo
     hierarchical_memory --> private_repo
     web_grab --> obsidian
+    voice_notes --> hierarchical_memory
+    voice_notes --> obsidian
     lean_prover --> discussion_partners
     session_planner --> hierarchical_memory
     session_planner --> obsidian

--- a/skills/voice_notes/SKILL.md
+++ b/skills/voice_notes/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: voice_notes
+description: >
+  Transcribe audio files to text using OpenAI Whisper API. Use when the user
+  has a voice memo, audio recording, or any audio file they want transcribed.
+  Do NOT use for video files or live audio streams.
+allowed-tools: Bash(uv run *)
+---
+
+Transcribe audio files to text using the OpenAI Whisper API.
+
+## Usage
+
+```bash
+uv run --directory SKILL_DIR python scripts/transcribe.py FILE [OPTIONS]
+```
+
+Where `SKILL_DIR` is the directory containing this skill.
+
+### Options
+
+- `FILE` — Path to audio file (mp3, mp4, m4a, wav, webm, mpeg, mpga, oga, ogg)
+- `--language` / `-l` — ISO-639-1 language code (e.g. `en`, `es`, `ja`). Auto-detected if omitted.
+- `--output` / `-o` — Write transcript to this file instead of stdout
+- `--model` / `-m` — Whisper model (default: `gpt-4o-mini-transcribe`)
+
+## After Transcription
+
+1. Read the transcript output
+2. Ask the user what to do with it:
+   - Save to hierarchical_memory as a daily note
+   - Save to obsidian as a knowledge graph note
+   - Summarize and extract action items
+   - Just display the raw text
+
+## Requirements
+
+- `OPENAI_API_KEY` environment variable must be set (same key used by discussion_partners)
+- Supported formats: mp3, mp4, m4a, wav, webm, mpeg, mpga, oga, ogg
+- Max file size: 25MB per OpenAI API limit

--- a/skills/voice_notes/scripts/transcribe.py
+++ b/skills/voice_notes/scripts/transcribe.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Transcribe audio files using OpenAI Whisper API."""
+
+import os
+from pathlib import Path
+
+import click
+
+SUPPORTED_FORMATS = {".mp3", ".mp4", ".m4a", ".wav", ".webm", ".mpeg", ".mpga", ".oga", ".ogg"}
+MAX_FILE_SIZE = 25 * 1024 * 1024  # 25MB
+
+
+@click.command()
+@click.argument("file", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--language",
+    "-l",
+    default=None,
+    help="ISO-639-1 language code (e.g. en, es, ja). Auto-detected if omitted.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write transcript to this file instead of stdout.",
+)
+@click.option(
+    "--model",
+    "-m",
+    default="gpt-4o-mini-transcribe",
+    help="Whisper model to use.",
+)
+def transcribe(file: Path, language: str | None, output: Path | None, model: str) -> None:
+    """Transcribe an audio file using OpenAI Whisper API."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise click.ClickException("OPENAI_API_KEY environment variable is not set")
+
+    suffix = file.suffix.lower()
+    if suffix not in SUPPORTED_FORMATS:
+        raise click.ClickException(
+            f"Unsupported format '{suffix}'. Supported: {', '.join(sorted(SUPPORTED_FORMATS))}"
+        )
+
+    file_size = file.stat().st_size
+    if file_size > MAX_FILE_SIZE:
+        raise click.ClickException(
+            f"File too large ({file_size / 1024 / 1024:.1f}MB). Max is 25MB."
+        )
+
+    import openai
+
+    client = openai.OpenAI(api_key=api_key)
+
+    with open(file, "rb") as audio_file:
+        kwargs: dict = {
+            "model": model,
+            "file": audio_file,
+        }
+        if language is not None:
+            kwargs["language"] = language
+
+        transcript = client.audio.transcriptions.create(**kwargs)
+
+    text = transcript.text if hasattr(transcript, "text") else str(transcript)
+
+    if output is not None:
+        output.write_text(text)
+        click.echo(f"Transcript written to {output}")
+    else:
+        click.echo(text)
+
+
+if __name__ == "__main__":
+    transcribe()

--- a/tests/unit/test_transcribe.py
+++ b/tests/unit/test_transcribe.py
@@ -1,0 +1,191 @@
+"""Tests for the voice_notes transcription CLI."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+# Import transcribe.py from the skill directory
+_spec = importlib.util.spec_from_file_location(
+    "transcribe",
+    Path(__file__).resolve().parents[2] / "skills" / "voice_notes" / "scripts" / "transcribe.py",
+)
+assert _spec is not None and _spec.loader is not None
+transcribe = importlib.util.module_from_spec(_spec)
+sys.modules["transcribe"] = transcribe
+_spec.loader.exec_module(transcribe)
+
+
+@pytest.fixture()
+def audio_file(tmp_path: Path) -> Path:
+    """Create a fake audio file."""
+    f = tmp_path / "test.mp3"
+    f.write_bytes(b"fake audio content")
+    return f
+
+
+@pytest.fixture()
+def large_audio_file(tmp_path: Path) -> Path:
+    """Create an audio file exceeding the size limit."""
+    f = tmp_path / "large.mp3"
+    f.write_bytes(b"x" * (26 * 1024 * 1024))  # 26MB
+    return f
+
+
+class TestInputValidation:
+    def test_missing_api_key(self, audio_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        result = CliRunner().invoke(transcribe.transcribe, [str(audio_file)])
+        assert result.exit_code != 0
+        assert "OPENAI_API_KEY" in result.output
+
+    def test_unsupported_format(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        f = tmp_path / "test.txt"
+        f.write_text("not audio")
+        result = CliRunner().invoke(transcribe.transcribe, [str(f)])
+        assert result.exit_code != 0
+        assert "Unsupported format" in result.output
+
+    def test_file_too_large(self, large_audio_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        result = CliRunner().invoke(transcribe.transcribe, [str(large_audio_file)])
+        assert result.exit_code != 0
+        assert "too large" in result.output
+
+    def test_nonexistent_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        result = CliRunner().invoke(transcribe.transcribe, ["/nonexistent/audio.mp3"])
+        assert result.exit_code != 0
+
+
+class TestSupportedFormats:
+    @pytest.mark.parametrize(
+        "ext", [".mp3", ".mp4", ".m4a", ".wav", ".webm", ".mpeg", ".mpga", ".oga", ".ogg"]
+    )
+    def test_accepted_format(
+        self, tmp_path: Path, ext: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        f = tmp_path / f"test{ext}"
+        f.write_bytes(b"fake audio")
+
+        mock_transcript = MagicMock()
+        mock_transcript.text = "hello world"
+
+        with patch("openai.OpenAI") as mock_client:
+            mock_client.return_value.audio.transcriptions.create.return_value = mock_transcript
+            result = CliRunner().invoke(transcribe.transcribe, [str(f)])
+
+        assert result.exit_code == 0
+        assert "hello world" in result.output
+
+
+class TestTranscription:
+    def test_stdout_output(self, audio_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        mock_transcript = MagicMock()
+        mock_transcript.text = "This is the transcribed text."
+
+        with patch("openai.OpenAI") as mock_client:
+            mock_client.return_value.audio.transcriptions.create.return_value = mock_transcript
+            result = CliRunner().invoke(transcribe.transcribe, [str(audio_file)])
+
+        assert result.exit_code == 0
+        assert "This is the transcribed text." in result.output
+
+    def test_file_output(
+        self, audio_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        out_file = tmp_path / "transcript.txt"
+
+        mock_transcript = MagicMock()
+        mock_transcript.text = "Written to file."
+
+        with patch("openai.OpenAI") as mock_client:
+            mock_client.return_value.audio.transcriptions.create.return_value = mock_transcript
+            result = CliRunner().invoke(
+                transcribe.transcribe, [str(audio_file), "--output", str(out_file)]
+            )
+
+        assert result.exit_code == 0
+        assert out_file.read_text() == "Written to file."
+        assert "Transcript written to" in result.output
+
+    def test_language_option(self, audio_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        mock_transcript = MagicMock()
+        mock_transcript.text = "Hola mundo."
+
+        with patch("openai.OpenAI") as mock_client:
+            mock_create = mock_client.return_value.audio.transcriptions.create
+            mock_create.return_value = mock_transcript
+            result = CliRunner().invoke(
+                transcribe.transcribe, [str(audio_file), "--language", "es"]
+            )
+
+            call_kwargs = mock_create.call_args[1]
+            assert call_kwargs["language"] == "es"
+
+        assert result.exit_code == 0
+
+    def test_no_language_omits_param(
+        self, audio_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        mock_transcript = MagicMock()
+        mock_transcript.text = "Auto detected."
+
+        with patch("openai.OpenAI") as mock_client:
+            mock_create = mock_client.return_value.audio.transcriptions.create
+            mock_create.return_value = mock_transcript
+            result = CliRunner().invoke(transcribe.transcribe, [str(audio_file)])
+
+            call_kwargs = mock_create.call_args[1]
+            assert "language" not in call_kwargs
+
+        assert result.exit_code == 0
+
+    def test_custom_model(self, audio_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        mock_transcript = MagicMock()
+        mock_transcript.text = "Custom model output."
+
+        with patch("openai.OpenAI") as mock_client:
+            mock_create = mock_client.return_value.audio.transcriptions.create
+            mock_create.return_value = mock_transcript
+            result = CliRunner().invoke(
+                transcribe.transcribe, [str(audio_file), "--model", "whisper-1"]
+            )
+
+            call_kwargs = mock_create.call_args[1]
+            assert call_kwargs["model"] == "whisper-1"
+
+        assert result.exit_code == 0
+
+    def test_api_key_passed_to_client(
+        self, audio_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key-123")
+        mock_transcript = MagicMock()
+        mock_transcript.text = "test"
+
+        with patch("openai.OpenAI") as mock_client:
+            mock_client.return_value.audio.transcriptions.create.return_value = mock_transcript
+            CliRunner().invoke(transcribe.transcribe, [str(audio_file)])
+
+            mock_client.assert_called_once_with(api_key="sk-test-key-123")
+
+
+class TestConstants:
+    def test_supported_formats_complete(self) -> None:
+        expected = {".mp3", ".mp4", ".m4a", ".wav", ".webm", ".mpeg", ".mpga", ".oga", ".ogg"}
+        assert transcribe.SUPPORTED_FORMATS == expected
+
+    def test_max_file_size(self) -> None:
+        assert transcribe.MAX_FILE_SIZE == 25 * 1024 * 1024


### PR DESCRIPTION
## Summary

- New `voice_notes` skill that transcribes audio files using OpenAI Whisper API (`gpt-4o-mini-transcribe` model by default)
- Click CLI script (`scripts/transcribe.py`) with format validation, file size checking, language selection, and output options
- 18 unit tests covering input validation, all 9 supported formats, transcription output modes, and API parameter passing
- Updated README: added to Capture section, skill graph, with connections to `hierarchical_memory` and `obsidian`

Fixes #63

## Test plan

- [x] All 233 tests pass (`uv run python -m pytest tests/ -v`)
- [x] Lint clean (`make lint`)
- [x] SKILL.md passes frontmatter validation (name, description, snake_case)
- [ ] Manual test with real audio file and `OPENAI_API_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)