### PR TITLE
Add vector search skill (fixes #68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Skills are grouped by their role in the capture → organize → process pipelin
 | [daily_briefing](skills/daily_briefing/) | Prompt | Morning summary from memory, tasks, and vault |
 | [reminders](skills/reminders/) | Prompt | Time-aware reminders stored as markdown checklist in obsidian |
 | [session_planner](skills/session_planner/) | Prompt | Plan a focused work session from memory, tasks, and context |
+| [vector_search](skills/vector_search/) | Python | Semantic search over memory and obsidian vault via embeddings |
 
 ### Process
 
@@ -121,6 +122,8 @@ graph LR
     session_planner --> obsidian
     daily_briefing --> hierarchical_memory
     daily_briefing --> obsidian
+    vector_search --> hierarchical_memory
+    vector_search --> obsidian
 ```
 
 Standalone skills (no imports): `api_key_checker`, `concise_writing`, `data_science`, `forecast`, `gh_cli`, `pdf_to_markdown`, `pr_review`, `skill_pruner`, `skill_stealer`
@@ -217,7 +220,7 @@ Rigid subdirectories (Claude creates these automatically):
 
 | Variable | Used by |
 |----------|---------|
-| `OPENAI_API_KEY` | `discussion_partners` (`openai:` and `openai-responses:` models) |
+| `OPENAI_API_KEY` | `discussion_partners` (`openai:` and `openai-responses:` models), `vector_search` (embeddings) |
 | `ANTHROPIC_API_KEY` | `discussion_partners` (`anthropic:` models) |
 | `GOOGLE_API_KEY` | `discussion_partners` (`google-gla:` models) |
 

--- a/skills/vector_search/SKILL.md
+++ b/skills/vector_search/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: vector_search
+description: >
+  Semantic search over memory files and obsidian vault via embeddings.
+  WHEN: User asks "what do I know about X", needs to find related notes
+  across memory and knowledge graph, or keyword search returns too many
+  or too few results. Also useful for finding thematically related notes.
+  WHEN NOT: Exact keyword search (use Grep), finding a specific file by
+  name (use Glob), or reading a known file (use Read).
+---
+
+Semantic vector search over `$CLAUDE_OBSIDIAN_DIR` using OpenAI embeddings.
+
+Requires `OPENAI_API_KEY` environment variable.
+
+## Quick Reference
+
+| Command | What it does |
+|---------|-------------|
+| `index` | Build/update embedding index (only re-embeds changed files) |
+| `search "query"` | Find semantically similar chunks |
+| `status` | Show index stats (chunks, files, size) |
+
+## Commands
+
+All commands:
+```bash
+uv run --directory SKILL_DIR python scripts/vector_search.py <command> [args]
+```
+
+Where `SKILL_DIR` is the directory containing this skill.
+
+### Build the index
+
+```bash
+# Index everything (memory + knowledge_graph)
+uv run --directory SKILL_DIR python scripts/vector_search.py index
+
+# Index only memory files
+uv run --directory SKILL_DIR python scripts/vector_search.py index --scope memory
+
+# Force full re-index (ignore cache)
+uv run --directory SKILL_DIR python scripts/vector_search.py index --force
+```
+
+Incremental by default — only re-embeds files whose mtime changed. Uses `text-embedding-3-small` at 256 dimensions for a compact index.
+
+### Search
+
+```bash
+# Basic semantic search
+uv run --directory SKILL_DIR python scripts/vector_search.py search "March Madness modeling approach"
+
+# More results
+uv run --directory SKILL_DIR python scripts/vector_search.py search "Board game development" -k 10
+
+# Filter to memory only
+uv run --directory SKILL_DIR python scripts/vector_search.py search "tax prep" --scope memory
+
+# Set minimum similarity threshold
+uv run --directory SKILL_DIR python scripts/vector_search.py search "pydantic ai tools" --threshold 0.3
+```
+
+Returns top-k results ranked by cosine similarity, with file path, score, and text preview.
+
+### Check status
+
+```bash
+uv run --directory SKILL_DIR python scripts/vector_search.py status
+```
+
+Shows model, dimensions, last indexed time, chunk/file counts, and index file size.
+
+## When to Use
+
+| Need | Tool | Why |
+|------|------|-----|
+| "What do I know about X?" | `vector_search search` | Finds semantically related content across all files |
+| Exact keyword match | `Grep` | Faster, no API call needed |
+| Find file by name | `Glob` | Pattern matching, no index needed |
+| Browse a specific file | `Read` | Direct access |
+
+## How It Works
+
+1. **Chunking**: Markdown files are split by `##` headers, then by paragraphs if sections are too long (max 2000 chars per chunk)
+2. **Embedding**: Each chunk is embedded via OpenAI `text-embedding-3-small` (256 dimensions)
+3. **Storage**: Index stored as `.vector_index.json` in the obsidian vault root (dotfile, ignored by obsidian)
+4. **Search**: Query is embedded, cosine similarity computed against all indexed chunks, top-k returned
+
+## Maintenance
+
+Re-index periodically or after adding many notes. The index command is incremental — unchanged files are skipped. Use `--force` to rebuild from scratch if the index seems stale.
+
+The index file is gitignored (dotfile). It does not need to be committed or synced.

--- a/skills/vector_search/scripts/vector_search.py
+++ b/skills/vector_search/scripts/vector_search.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Semantic vector search over memory and obsidian vault files."""
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+
+import click
+import openai
+
+OBSIDIAN_DIR = Path(
+    os.environ.get("CLAUDE_OBSIDIAN_DIR", str(Path.home() / "claude" / "obsidian"))
+).expanduser()
+MEMORY_DIR = OBSIDIAN_DIR / "memory"
+KNOWLEDGE_DIR = OBSIDIAN_DIR / "knowledge_graph"
+INDEX_PATH = OBSIDIAN_DIR / ".vector_index.json"
+
+EMBEDDING_MODEL = "text-embedding-3-small"
+EMBEDDING_DIMENSIONS = 256  # reduced dimensions for smaller index, still good quality
+MAX_CHUNK_CHARS = 2000
+DEFAULT_TOP_K = 5
+
+
+def _get_client() -> openai.OpenAI:
+    """Create OpenAI client. Requires OPENAI_API_KEY env var."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise click.ClickException("OPENAI_API_KEY environment variable not set")
+    return openai.OpenAI(api_key=api_key)
+
+
+def _chunk_markdown(text: str, max_chars: int = MAX_CHUNK_CHARS) -> list[str]:
+    """Split markdown into chunks by sections, falling back to paragraphs.
+
+    Tries to split on ## headers first. If a section is still too long,
+    splits on paragraphs (double newline). Preserves the header in each chunk.
+    """
+    chunks: list[str] = []
+
+    # Split on ## headers (keep the header with its content)
+    sections = []
+    current: list[str] = []
+    for line in text.split("\n"):
+        if line.startswith("## ") and current:
+            sections.append("\n".join(current))
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        sections.append("\n".join(current))
+
+    for section in sections:
+        section = section.strip()
+        if not section:
+            continue
+        if len(section) <= max_chars:
+            chunks.append(section)
+        else:
+            # Split long sections on paragraphs
+            paragraphs = section.split("\n\n")
+            current_chunk: list[str] = []
+            current_len = 0
+            for para in paragraphs:
+                para = para.strip()
+                if not para:
+                    continue
+                if current_len + len(para) + 2 > max_chars and current_chunk:
+                    chunks.append("\n\n".join(current_chunk))
+                    current_chunk = [para]
+                    current_len = len(para)
+                else:
+                    current_chunk.append(para)
+                    current_len += len(para) + 2
+            if current_chunk:
+                chunks.append("\n\n".join(current_chunk))
+
+    return [c for c in chunks if c.strip()]
+
+
+def _collect_files(scope: str) -> list[Path]:
+    """Collect markdown files based on scope: 'all', 'memory', or 'knowledge'."""
+    files: list[Path] = []
+    if scope in ("all", "memory") and MEMORY_DIR.is_dir():
+        files.extend(sorted(MEMORY_DIR.glob("*.md")))
+    if scope in ("all", "knowledge") and KNOWLEDGE_DIR.is_dir():
+        files.extend(sorted(KNOWLEDGE_DIR.rglob("*.md")))
+    return files
+
+
+def _load_index() -> dict:
+    """Load the vector index from disk."""
+    if INDEX_PATH.exists():
+        return json.loads(INDEX_PATH.read_text())
+    return {"model": EMBEDDING_MODEL, "dimensions": EMBEDDING_DIMENSIONS, "entries": []}
+
+
+def _save_index(index: dict) -> None:
+    """Save the vector index to disk."""
+    INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    INDEX_PATH.write_text(json.dumps(index))
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _embed_texts(client: openai.OpenAI, texts: list[str]) -> list[list[float]]:
+    """Embed a batch of texts using OpenAI API. Handles batching."""
+    all_embeddings: list[list[float]] = []
+    batch_size = 100  # OpenAI supports up to 2048, but keep batches reasonable
+    for i in range(0, len(texts), batch_size):
+        batch = texts[i : i + batch_size]
+        response = client.embeddings.create(
+            model=EMBEDDING_MODEL,
+            input=batch,
+            dimensions=EMBEDDING_DIMENSIONS,
+        )
+        all_embeddings.extend([item.embedding for item in response.data])
+    return all_embeddings
+
+
+@click.group()
+def cli() -> None:
+    """Semantic vector search over memory and obsidian vault."""
+
+
+@cli.command()
+@click.option(
+    "--scope",
+    type=click.Choice(["all", "memory", "knowledge"]),
+    default="all",
+    help="Which files to index.",
+)
+@click.option("--force", is_flag=True, help="Re-index all files, ignoring mtime cache.")
+def index(scope: str, force: bool) -> None:
+    """Build or update the vector search index.
+
+    Scans memory and knowledge_graph files, chunks them, and generates
+    embeddings via OpenAI. Only re-embeds files that changed since last index.
+    """
+    existing = _load_index()
+
+    # Build mtime lookup from existing index
+    existing_lookup: dict[str, dict] = {}
+    if not force:
+        for entry in existing.get("entries", []):
+            key = f"{entry['file']}::{entry['chunk_index']}"
+            existing_lookup[key] = entry
+
+    files = _collect_files(scope)
+    if not files:
+        click.echo("No files found to index.")
+        return
+
+    new_entries: list[dict] = []
+    files_scanned = 0
+    files_embedded = 0
+    chunks_to_embed: list[tuple[str, int, str, float]] = []  # file, chunk_idx, text, mtime
+
+    for fpath in files:
+        files_scanned += 1
+        rel = str(fpath.relative_to(OBSIDIAN_DIR))
+        mtime = fpath.stat().st_mtime
+        text = fpath.read_text(errors="replace")
+        chunks = _chunk_markdown(text)
+
+        file_needs_embed = False
+        for ci, chunk in enumerate(chunks):
+            key = f"{rel}::{ci}"
+            cached = existing_lookup.get(key)
+            if cached and cached.get("mtime", 0) >= mtime and cached.get("text") == chunk:
+                new_entries.append(cached)
+            else:
+                file_needs_embed = True
+                chunks_to_embed.append((rel, ci, chunk, mtime))
+
+        if file_needs_embed:
+            files_embedded += 1
+
+    # Embed all new/changed chunks in batches
+    if chunks_to_embed:
+        client = _get_client()
+        texts = [c[2] for c in chunks_to_embed]
+        click.echo(f"Embedding {len(texts)} chunks from {files_embedded} files...")
+        embeddings = _embed_texts(client, texts)
+        for (rel, ci, chunk, mtime), embedding in zip(chunks_to_embed, embeddings):
+            new_entries.append(
+                {
+                    "file": rel,
+                    "chunk_index": ci,
+                    "text": chunk,
+                    "mtime": mtime,
+                    "embedding": embedding,
+                }
+            )
+    else:
+        click.echo("All files up to date, nothing to embed.")
+
+    # Sort entries by file and chunk index for deterministic output
+    new_entries.sort(key=lambda e: (e["file"], e["chunk_index"]))
+
+    index_data = {
+        "model": EMBEDDING_MODEL,
+        "dimensions": EMBEDDING_DIMENSIONS,
+        "indexed_at": time.time(),
+        "entries": new_entries,
+    }
+    _save_index(index_data)
+    click.echo(
+        f"Index updated: {len(new_entries)} chunks from {files_scanned} files. "
+        f"({files_embedded} files re-embedded)"
+    )
+
+
+@cli.command()
+@click.argument("query")
+@click.option("-k", "--top-k", default=DEFAULT_TOP_K, help="Number of results to return.")
+@click.option(
+    "--scope",
+    type=click.Choice(["all", "memory", "knowledge"]),
+    default="all",
+    help="Filter results by scope.",
+)
+@click.option("--threshold", type=float, default=0.0, help="Minimum similarity score.")
+def search(query: str, top_k: int, scope: str, threshold: float) -> None:
+    """Search the index semantically. Returns top-k most similar chunks."""
+    index_data = _load_index()
+    entries = index_data.get("entries", [])
+    if not entries:
+        click.echo("Index is empty. Run 'index' first.")
+        return
+
+    # Filter by scope
+    if scope == "memory":
+        entries = [e for e in entries if e["file"].startswith("memory/")]
+    elif scope == "knowledge":
+        entries = [e for e in entries if e["file"].startswith("knowledge_graph/")]
+
+    if not entries:
+        click.echo(f"No indexed entries in scope '{scope}'.")
+        return
+
+    client = _get_client()
+    response = client.embeddings.create(
+        model=EMBEDDING_MODEL,
+        input=[query],
+        dimensions=EMBEDDING_DIMENSIONS,
+    )
+    query_embedding = response.data[0].embedding
+
+    # Score all entries
+    scored = []
+    for entry in entries:
+        sim = _cosine_similarity(query_embedding, entry["embedding"])
+        if sim >= threshold:
+            scored.append((sim, entry))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    results = scored[:top_k]
+
+    if not results:
+        click.echo("No results above threshold.")
+        return
+
+    for i, (score, entry) in enumerate(results, 1):
+        click.echo(f"\n--- Result {i} (score: {score:.4f}) ---")
+        click.echo(f"File: {entry['file']}")
+        # Show a preview of the chunk (first 300 chars)
+        preview = entry["text"][:300]
+        if len(entry["text"]) > 300:
+            preview += "..."
+        click.echo(preview)
+
+
+@cli.command()
+def status() -> None:
+    """Show index statistics."""
+    if not INDEX_PATH.exists():
+        click.echo("No index found. Run 'index' to build one.")
+        return
+
+    index_data = _load_index()
+    entries = index_data.get("entries", [])
+    indexed_at = index_data.get("indexed_at", 0)
+
+    # Count files and chunks
+    files = set()
+    memory_chunks = 0
+    knowledge_chunks = 0
+    for entry in entries:
+        files.add(entry["file"])
+        if entry["file"].startswith("memory/"):
+            memory_chunks += 1
+        elif entry["file"].startswith("knowledge_graph/"):
+            knowledge_chunks += 1
+
+    from datetime import datetime
+
+    ts = datetime.fromtimestamp(indexed_at).strftime("%Y-%m-%d %H:%M:%S") if indexed_at else "never"
+
+    click.echo(f"Model: {index_data.get('model', 'unknown')}")
+    click.echo(f"Dimensions: {index_data.get('dimensions', 'unknown')}")
+    click.echo(f"Last indexed: {ts}")
+    click.echo(f"Total chunks: {len(entries)}")
+    click.echo(f"Total files: {len(files)}")
+    click.echo(f"  Memory chunks: {memory_chunks}")
+    click.echo(f"  Knowledge chunks: {knowledge_chunks}")
+
+    # Index file size
+    size_mb = INDEX_PATH.stat().st_size / (1024 * 1024)
+    click.echo(f"Index size: {size_mb:.2f} MB")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/unit/test_vector_search.py
+++ b/tests/unit/test_vector_search.py
@@ -1,0 +1,499 @@
+"""Tests for the vector search CLI."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+# Import vector_search.py from the skill directory
+_spec = importlib.util.spec_from_file_location(
+    "vector_search",
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "vector_search"
+    / "scripts"
+    / "vector_search.py",
+)
+assert _spec is not None and _spec.loader is not None
+vs = importlib.util.module_from_spec(_spec)
+sys.modules["vector_search"] = vs
+_spec.loader.exec_module(vs)
+
+
+@pytest.fixture()
+def obsidian_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Set up a temp obsidian directory with memory and knowledge_graph subdirs."""
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    knowledge_dir = tmp_path / "knowledge_graph"
+    knowledge_dir.mkdir()
+    monkeypatch.setattr(vs, "OBSIDIAN_DIR", tmp_path)
+    monkeypatch.setattr(vs, "MEMORY_DIR", memory_dir)
+    monkeypatch.setattr(vs, "KNOWLEDGE_DIR", knowledge_dir)
+    monkeypatch.setattr(vs, "INDEX_PATH", tmp_path / ".vector_index.json")
+    return tmp_path
+
+
+def _make_embedding(dim: int = 256, seed: float = 0.0) -> list[float]:
+    """Create a deterministic fake embedding vector."""
+    import math
+
+    return [math.sin(seed + i) for i in range(dim)]
+
+
+class TestChunkMarkdown:
+    def test_empty_text(self) -> None:
+        assert vs._chunk_markdown("") == []
+
+    def test_short_text(self) -> None:
+        text = "Hello world"
+        chunks = vs._chunk_markdown(text)
+        assert len(chunks) == 1
+        assert chunks[0] == "Hello world"
+
+    def test_splits_on_headers(self) -> None:
+        text = "## Section 1\nContent 1\n\n## Section 2\nContent 2"
+        chunks = vs._chunk_markdown(text)
+        assert len(chunks) == 2
+        assert "Section 1" in chunks[0]
+        assert "Section 2" in chunks[1]
+
+    def test_preserves_header_in_chunk(self) -> None:
+        text = "## My Section\nSome content here"
+        chunks = vs._chunk_markdown(text)
+        assert len(chunks) == 1
+        assert chunks[0].startswith("## My Section")
+
+    def test_splits_long_section_into_paragraphs(self) -> None:
+        # Create a section longer than MAX_CHUNK_CHARS
+        para = "A" * 800
+        text = f"## Big Section\n\n{para}\n\n{para}\n\n{para}\n\n{para}"
+        chunks = vs._chunk_markdown(text, max_chars=2000)
+        assert len(chunks) > 1
+
+    def test_no_empty_chunks(self) -> None:
+        text = "## A\n\n\n\n## B\n\n\n\n## C\nContent"
+        chunks = vs._chunk_markdown(text)
+        for chunk in chunks:
+            assert chunk.strip() != ""
+
+    def test_content_before_first_header(self) -> None:
+        text = "Some preamble\n\n## Section\nContent"
+        chunks = vs._chunk_markdown(text)
+        assert len(chunks) == 2
+        assert "preamble" in chunks[0]
+        assert "Section" in chunks[1]
+
+
+class TestCollectFiles:
+    def test_all_scope(self, obsidian_dir: Path) -> None:
+        (obsidian_dir / "memory" / "2026-01-01.md").write_text("day note")
+        (obsidian_dir / "knowledge_graph" / "test.md").write_text("knowledge")
+        files = vs._collect_files("all")
+        assert len(files) == 2
+
+    def test_memory_scope(self, obsidian_dir: Path) -> None:
+        (obsidian_dir / "memory" / "2026-01-01.md").write_text("day note")
+        (obsidian_dir / "knowledge_graph" / "test.md").write_text("knowledge")
+        files = vs._collect_files("memory")
+        assert len(files) == 1
+        assert "memory" in str(files[0])
+
+    def test_knowledge_scope(self, obsidian_dir: Path) -> None:
+        (obsidian_dir / "memory" / "2026-01-01.md").write_text("day note")
+        (obsidian_dir / "knowledge_graph" / "test.md").write_text("knowledge")
+        files = vs._collect_files("knowledge")
+        assert len(files) == 1
+        assert "knowledge_graph" in str(files[0])
+
+    def test_empty_dirs(self, obsidian_dir: Path) -> None:
+        files = vs._collect_files("all")
+        assert len(files) == 0
+
+    def test_knowledge_rglob(self, obsidian_dir: Path) -> None:
+        subdir = obsidian_dir / "knowledge_graph" / "Technical"
+        subdir.mkdir()
+        (subdir / "note.md").write_text("nested note")
+        files = vs._collect_files("knowledge")
+        assert len(files) == 1
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors(self) -> None:
+        v = [1.0, 2.0, 3.0]
+        assert abs(vs._cosine_similarity(v, v) - 1.0) < 1e-10
+
+    def test_orthogonal_vectors(self) -> None:
+        a = [1.0, 0.0]
+        b = [0.0, 1.0]
+        assert abs(vs._cosine_similarity(a, b)) < 1e-10
+
+    def test_opposite_vectors(self) -> None:
+        a = [1.0, 0.0]
+        b = [-1.0, 0.0]
+        assert abs(vs._cosine_similarity(a, b) - (-1.0)) < 1e-10
+
+    def test_zero_vector(self) -> None:
+        a = [0.0, 0.0]
+        b = [1.0, 2.0]
+        assert vs._cosine_similarity(a, b) == 0.0
+
+
+class TestIndexSaveLoad:
+    def test_save_and_load(self, obsidian_dir: Path) -> None:
+        index_data = {
+            "model": "test-model",
+            "dimensions": 3,
+            "entries": [
+                {
+                    "file": "memory/test.md",
+                    "chunk_index": 0,
+                    "text": "hello",
+                    "mtime": 1000.0,
+                    "embedding": [1.0, 2.0, 3.0],
+                }
+            ],
+        }
+        vs._save_index(index_data)
+        loaded = vs._load_index()
+        assert loaded["model"] == "test-model"
+        assert len(loaded["entries"]) == 1
+        assert loaded["entries"][0]["text"] == "hello"
+
+    def test_load_missing_index(self, obsidian_dir: Path) -> None:
+        loaded = vs._load_index()
+        assert loaded["entries"] == []
+        assert loaded["model"] == vs.EMBEDDING_MODEL
+
+
+class TestIndexCommand:
+    def test_index_no_files(self, obsidian_dir: Path) -> None:
+        result = CliRunner().invoke(vs.cli, ["index"])
+        assert result.exit_code == 0
+        assert "No files found" in result.output
+
+    @patch.object(vs, "_get_client")
+    def test_index_creates_entries(self, mock_get_client: MagicMock, obsidian_dir: Path) -> None:
+        # Create a test file
+        (obsidian_dir / "memory" / "test.md").write_text("## Hello\nWorld")
+
+        # Mock the OpenAI client
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = _make_embedding()
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        result = CliRunner().invoke(vs.cli, ["index"])
+        assert result.exit_code == 0
+        assert "Embedding" in result.output
+        assert "Index updated" in result.output
+
+        # Verify index was saved
+        index = vs._load_index()
+        assert len(index["entries"]) == 1
+        assert index["entries"][0]["file"] == "memory/test.md"
+
+    @patch.object(vs, "_get_client")
+    def test_index_incremental_skip(self, mock_get_client: MagicMock, obsidian_dir: Path) -> None:
+        # Pre-populate index with a matching entry
+        fpath = obsidian_dir / "memory" / "test.md"
+        fpath.write_text("## Hello\nWorld")
+        mtime = fpath.stat().st_mtime
+
+        index_data = {
+            "model": vs.EMBEDDING_MODEL,
+            "dimensions": vs.EMBEDDING_DIMENSIONS,
+            "entries": [
+                {
+                    "file": "memory/test.md",
+                    "chunk_index": 0,
+                    "text": "## Hello\nWorld",
+                    "mtime": mtime,
+                    "embedding": _make_embedding(),
+                }
+            ],
+        }
+        vs._save_index(index_data)
+
+        result = CliRunner().invoke(vs.cli, ["index"])
+        assert result.exit_code == 0
+        assert "nothing to embed" in result.output.lower()
+        # Client should not have been called
+        mock_get_client.assert_not_called()
+
+    @patch.object(vs, "_get_client")
+    def test_index_force_reembeds(self, mock_get_client: MagicMock, obsidian_dir: Path) -> None:
+        # Pre-populate index
+        fpath = obsidian_dir / "memory" / "test.md"
+        fpath.write_text("## Hello\nWorld")
+        mtime = fpath.stat().st_mtime
+
+        index_data = {
+            "model": vs.EMBEDDING_MODEL,
+            "dimensions": vs.EMBEDDING_DIMENSIONS,
+            "entries": [
+                {
+                    "file": "memory/test.md",
+                    "chunk_index": 0,
+                    "text": "## Hello\nWorld",
+                    "mtime": mtime,
+                    "embedding": _make_embedding(),
+                }
+            ],
+        }
+        vs._save_index(index_data)
+
+        # Mock client for force re-embed
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = _make_embedding(seed=1.0)
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        result = CliRunner().invoke(vs.cli, ["index", "--force"])
+        assert result.exit_code == 0
+        assert "Embedding" in result.output
+
+    @patch.object(vs, "_get_client")
+    def test_index_scope_memory(self, mock_get_client: MagicMock, obsidian_dir: Path) -> None:
+        (obsidian_dir / "memory" / "test.md").write_text("memory note")
+        (obsidian_dir / "knowledge_graph" / "test.md").write_text("knowledge note")
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = _make_embedding()
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        result = CliRunner().invoke(vs.cli, ["index", "--scope", "memory"])
+        assert result.exit_code == 0
+
+        index = vs._load_index()
+        # Should only have memory entries
+        for entry in index["entries"]:
+            assert entry["file"].startswith("memory/")
+
+
+class TestSearchCommand:
+    def test_search_empty_index(self, obsidian_dir: Path) -> None:
+        result = CliRunner().invoke(vs.cli, ["search", "test query"])
+        assert result.exit_code == 0
+        assert "empty" in result.output.lower()
+
+    @patch.object(vs, "_get_client")
+    def test_search_returns_results(self, mock_get_client: MagicMock, obsidian_dir: Path) -> None:
+        # Pre-populate index
+        emb1 = _make_embedding(seed=0.0)
+        emb2 = _make_embedding(seed=5.0)
+        index_data = {
+            "model": vs.EMBEDDING_MODEL,
+            "dimensions": vs.EMBEDDING_DIMENSIONS,
+            "entries": [
+                {
+                    "file": "memory/2026-01-01.md",
+                    "chunk_index": 0,
+                    "text": "March Madness basketball predictions",
+                    "mtime": 1000.0,
+                    "embedding": emb1,
+                },
+                {
+                    "file": "knowledge_graph/Tax.md",
+                    "chunk_index": 0,
+                    "text": "Tax preparation notes for 2025",
+                    "mtime": 1000.0,
+                    "embedding": emb2,
+                },
+            ],
+        }
+        vs._save_index(index_data)
+
+        # Mock query embedding (similar to emb1)
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = _make_embedding(seed=0.1)  # close to emb1
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        result = CliRunner().invoke(vs.cli, ["search", "basketball"])
+        assert result.exit_code == 0
+        assert "Result 1" in result.output
+        assert "score:" in result.output
+
+    @patch.object(vs, "_get_client")
+    def test_search_scope_filter(self, mock_get_client: MagicMock, obsidian_dir: Path) -> None:
+        emb1 = _make_embedding(seed=0.0)
+        emb2 = _make_embedding(seed=0.0)  # same embedding, different scope
+        index_data = {
+            "model": vs.EMBEDDING_MODEL,
+            "dimensions": vs.EMBEDDING_DIMENSIONS,
+            "entries": [
+                {
+                    "file": "memory/test.md",
+                    "chunk_index": 0,
+                    "text": "memory content",
+                    "mtime": 1000.0,
+                    "embedding": emb1,
+                },
+                {
+                    "file": "knowledge_graph/test.md",
+                    "chunk_index": 0,
+                    "text": "knowledge content",
+                    "mtime": 1000.0,
+                    "embedding": emb2,
+                },
+            ],
+        }
+        vs._save_index(index_data)
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = _make_embedding(seed=0.0)
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        result = CliRunner().invoke(vs.cli, ["search", "test", "--scope", "knowledge"])
+        assert result.exit_code == 0
+        assert "knowledge_graph" in result.output
+        assert "memory/" not in result.output
+
+    @patch.object(vs, "_get_client")
+    def test_search_top_k(self, mock_get_client: MagicMock, obsidian_dir: Path) -> None:
+        entries = []
+        for i in range(10):
+            entries.append(
+                {
+                    "file": f"memory/note{i}.md",
+                    "chunk_index": 0,
+                    "text": f"Note {i} content",
+                    "mtime": 1000.0,
+                    "embedding": _make_embedding(seed=float(i)),
+                }
+            )
+        index_data = {
+            "model": vs.EMBEDDING_MODEL,
+            "dimensions": vs.EMBEDDING_DIMENSIONS,
+            "entries": entries,
+        }
+        vs._save_index(index_data)
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = _make_embedding(seed=0.0)
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        result = CliRunner().invoke(vs.cli, ["search", "test", "-k", "3"])
+        assert result.exit_code == 0
+        assert "Result 3" in result.output
+        assert "Result 4" not in result.output
+
+    @patch.object(vs, "_get_client")
+    def test_search_threshold(self, mock_get_client: MagicMock, obsidian_dir: Path) -> None:
+        index_data = {
+            "model": vs.EMBEDDING_MODEL,
+            "dimensions": vs.EMBEDDING_DIMENSIONS,
+            "entries": [
+                {
+                    "file": "memory/test.md",
+                    "chunk_index": 0,
+                    "text": "test content",
+                    "mtime": 1000.0,
+                    "embedding": _make_embedding(seed=100.0),  # very different
+                }
+            ],
+        }
+        vs._save_index(index_data)
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_embedding = MagicMock()
+        mock_embedding.embedding = _make_embedding(seed=0.0)
+        mock_response = MagicMock()
+        mock_response.data = [mock_embedding]
+        mock_client.embeddings.create.return_value = mock_response
+
+        result = CliRunner().invoke(vs.cli, ["search", "test", "--threshold", "0.99"])
+        assert result.exit_code == 0
+        assert "No results above threshold" in result.output
+
+
+class TestStatusCommand:
+    def test_status_no_index(self, obsidian_dir: Path) -> None:
+        result = CliRunner().invoke(vs.cli, ["status"])
+        assert result.exit_code == 0
+        assert "No index found" in result.output
+
+    def test_status_with_index(self, obsidian_dir: Path) -> None:
+        index_data = {
+            "model": vs.EMBEDDING_MODEL,
+            "dimensions": vs.EMBEDDING_DIMENSIONS,
+            "indexed_at": 1700000000.0,
+            "entries": [
+                {
+                    "file": "memory/test.md",
+                    "chunk_index": 0,
+                    "text": "hello",
+                    "mtime": 1000.0,
+                    "embedding": [1.0, 2.0, 3.0],
+                },
+                {
+                    "file": "knowledge_graph/note.md",
+                    "chunk_index": 0,
+                    "text": "world",
+                    "mtime": 1000.0,
+                    "embedding": [4.0, 5.0, 6.0],
+                },
+            ],
+        }
+        vs._save_index(index_data)
+
+        result = CliRunner().invoke(vs.cli, ["status"])
+        assert result.exit_code == 0
+        assert "Total chunks: 2" in result.output
+        assert "Total files: 2" in result.output
+        assert "Memory chunks: 1" in result.output
+        assert "Knowledge chunks: 1" in result.output
+        assert "MB" in result.output
+
+
+class TestEmbedTexts:
+    @patch.object(vs, "_get_client")
+    def test_single_batch(self, mock_get_client: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        emb1 = MagicMock()
+        emb1.embedding = [1.0, 2.0]
+        emb2 = MagicMock()
+        emb2.embedding = [3.0, 4.0]
+        mock_response = MagicMock()
+        mock_response.data = [emb1, emb2]
+        mock_client.embeddings.create.return_value = mock_response
+
+        result = vs._embed_texts(mock_client, ["hello", "world"])
+        assert len(result) == 2
+        assert result[0] == [1.0, 2.0]
+        assert result[1] == [3.0, 4.0]
+
+
+class TestGetClient:
+    def test_missing_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(Exception, match="OPENAI_API_KEY"):
+            vs._get_client()


### PR DESCRIPTION
## Summary

- New `vector_search` skill for semantic search over memory and obsidian vault
- Uses OpenAI `text-embedding-3-small` at 256 dimensions for compact, cost-effective embeddings
- Incremental indexing — only re-embeds files whose mtime changed since last index
- CLI commands: `index` (build/update), `search` (cosine similarity ranked), `status` (index stats)
- Chunks markdown by `##` headers, falls back to paragraph splitting for long sections
- Index stored as `.vector_index.json` in vault root (dotfile, ignored by obsidian)
- 32 new tests, 244 total passing, lint clean

## What it replaces

Previously the only search was keyword-based (Grep). This adds semantic search — "what do I know about X?" finds thematically related content even without exact keyword matches.

## Test plan

- [x] 32 unit tests covering chunking, cosine similarity, indexing, incremental skip, force rebuild, search with scope/threshold/top-k filtering, status display, error handling
- [x] All 244 tests passing
- [x] Ruff lint clean
- [x] Pre-commit hooks pass

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)