### PR TITLE
Add Google Docs/Sheets importer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Skills are grouped by their role in the capture → organize → process pipelin
 | [hierarchical_memory](skills/hierarchical_memory/) | Python | Quick notes aggregated into daily/monthly/overall summaries |
 | [web_grab](skills/web_grab/) | Python | Fetch URL content and save to obsidian — Playwright for JS SPAs |
 | [pdf_to_markdown](skills/pdf_to_markdown/) | Python | Convert PDFs to clean markdown for vault storage |
+| [google_docs](skills/google_docs/) | Python | Extract Google Docs and Sheets into obsidian notes |
 | [remember_session](skills/remember_session/) | Prompt | Save session learnings to memory and obsidian |
 | [skill_stealer](skills/skill_stealer/) | Prompt | Extract reusable skills from URLs into SKILL.md |
 
@@ -116,6 +117,7 @@ graph LR
     obsidian --> private_repo
     hierarchical_memory --> private_repo
     web_grab --> obsidian
+    google_docs --> obsidian
     lean_prover --> discussion_partners
     session_planner --> hierarchical_memory
     session_planner --> obsidian
@@ -220,6 +222,7 @@ Rigid subdirectories (Claude creates these automatically):
 | `OPENAI_API_KEY` | `discussion_partners` (`openai:` and `openai-responses:` models) |
 | `ANTHROPIC_API_KEY` | `discussion_partners` (`anthropic:` models) |
 | `GOOGLE_API_KEY` | `discussion_partners` (`google-gla:` models) |
+| `GOOGLE_APPLICATION_CREDENTIALS` | `google_docs` (path to service account JSON key) |
 
 Add keys to your shell profile (`~/.zshrc` or `~/.bashrc`). Claude Code sources your shell profile at startup — no extra configuration needed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 [project.optional-dependencies]
 pdf = ["marker-pdf>=1.0.0"]
 browser = ["playwright>=1.50.0"]
+google = ["google-api-python-client>=2.0.0"]
 
 [dependency-groups]
 dev = [

--- a/skills/google_docs/SKILL.md
+++ b/skills/google_docs/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: google_docs
+description: >
+  WHEN: User wants to extract content from Google Docs or Sheets into obsidian
+  notes, or needs to read a Google Doc/Sheet programmatically.
+  WHEN NOT: For non-Google URLs (use web_grab), for local files, or when the
+  user wants to write/edit Google Docs.
+---
+
+# Google Docs Importer
+
+Extract content from Google Docs and Sheets into obsidian notes.
+
+## Prerequisites
+
+### 1. Google Cloud Service Account
+
+This skill requires a Google Cloud service account with the Google Docs and Sheets APIs enabled.
+
+**One-time setup** (human task):
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a project (or use existing)
+3. Enable the **Google Docs API** and **Google Sheets API**
+4. Create a **Service Account** (IAM & Admin → Service Accounts)
+5. Create a JSON key for the service account and download it
+6. Set the path in your shell profile:
+   ```bash
+   export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/google/service-account.json"
+   ```
+7. **Share each Doc/Sheet** with the service account email (found in the JSON key file as `client_email`)
+
+### 2. Install optional dependency
+
+```bash
+uv sync --extra google
+```
+
+## Usage
+
+Extract a Google Doc to markdown:
+
+```bash
+uv run --directory SKILL_DIR python scripts/google_docs.py doc <DOC_ID>
+```
+
+Extract a Google Sheet to markdown:
+
+```bash
+uv run --directory SKILL_DIR python scripts/google_docs.py sheet <SHEET_ID>
+```
+
+Options:
+- `--output FILE` — write to file instead of stdout
+- `--sheet-name NAME` — (sheets only) extract a specific sheet tab
+
+### Finding the document ID
+
+The document ID is in the URL:
+- Docs: `https://docs.google.com/document/d/<DOC_ID>/edit`
+- Sheets: `https://docs.google.com/spreadsheets/d/<SHEET_ID>/edit`
+
+## After extraction
+
+Save the extracted content to obsidian following the `web_grab` pattern:
+1. Save as atomic note with Source URL and Date metadata
+2. Add topic tags and wiki-links
+3. Update or create MOC hub if needed

--- a/skills/google_docs/scripts/google_docs.py
+++ b/skills/google_docs/scripts/google_docs.py
@@ -1,0 +1,290 @@
+"""Extract content from Google Docs and Sheets as markdown."""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import click
+
+
+def _get_credentials_path() -> str:
+    """Get the service account credentials path from env."""
+    path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
+    if not path:
+        click.echo(
+            "Error: GOOGLE_APPLICATION_CREDENTIALS not set.\n"
+            "Set it to the path of your Google service account JSON key file.\n"
+            "See: skills/google_docs/SKILL.md for setup instructions.",
+            err=True,
+        )
+        sys.exit(1)
+    if not Path(path).exists():
+        click.echo(f"Error: Credentials file not found: {path}", err=True)
+        sys.exit(1)
+    return path
+
+
+def _build_service(api: str, version: str):
+    """Build a Google API service client."""
+    try:
+        from google.oauth2.service_account import Credentials
+        from googleapiclient.discovery import build
+    except ImportError:
+        click.echo(
+            "Error: google-api-python-client not installed.\nRun: uv sync --extra google",
+            err=True,
+        )
+        sys.exit(1)
+
+    creds_path = _get_credentials_path()
+    scopes = [
+        "https://www.googleapis.com/auth/documents.readonly",
+        "https://www.googleapis.com/auth/spreadsheets.readonly",
+    ]
+    creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
+    return build(api, version, credentials=creds)
+
+
+def _extract_doc_id(doc_id_or_url: str) -> str:
+    """Extract document ID from a URL or return as-is if already an ID."""
+    # Match Google Docs URL pattern
+    m = re.match(r"https?://docs\.google\.com/document/d/([a-zA-Z0-9_-]+)", doc_id_or_url)
+    if m:
+        return m.group(1)
+    # Match Google Sheets URL pattern
+    m = re.match(r"https?://docs\.google\.com/spreadsheets/d/([a-zA-Z0-9_-]+)", doc_id_or_url)
+    if m:
+        return m.group(1)
+    # Assume it's already an ID
+    return doc_id_or_url
+
+
+def _structural_element_to_md(element: dict) -> str:
+    """Convert a Google Docs structural element to markdown."""
+    if "paragraph" in element:
+        return _paragraph_to_md(element["paragraph"])
+    if "table" in element:
+        return _table_to_md(element["table"])
+    if "sectionBreak" in element:
+        return "\n---\n"
+    return ""
+
+
+def _paragraph_to_md(paragraph: dict) -> str:
+    """Convert a Google Docs paragraph to markdown."""
+    style = paragraph.get("paragraphStyle", {}).get("namedStyleType", "NORMAL_TEXT")
+    elements = paragraph.get("elements", [])
+
+    text_parts = []
+    for elem in elements:
+        text_run = elem.get("textRun", {})
+        content = text_run.get("content", "")
+        text_style = text_run.get("textStyle", {})
+
+        if text_style.get("bold"):
+            content = f"**{content.strip()}** " if content.strip() else content
+        if text_style.get("italic"):
+            content = f"*{content.strip()}* " if content.strip() else content
+        if text_style.get("link", {}).get("url"):
+            url = text_style["link"]["url"]
+            content = f"[{content.strip()}]({url}) " if content.strip() else content
+
+        text_parts.append(content)
+
+    text = "".join(text_parts).rstrip()
+
+    # Map heading styles
+    heading_map = {
+        "HEADING_1": "# ",
+        "HEADING_2": "## ",
+        "HEADING_3": "### ",
+        "HEADING_4": "#### ",
+        "HEADING_5": "##### ",
+        "HEADING_6": "###### ",
+    }
+
+    prefix = heading_map.get(style, "")
+
+    if not text:
+        return ""
+
+    # Handle list items
+    bullet = paragraph.get("bullet")
+    if bullet:
+        nesting = bullet.get("nestingLevel", 0)
+        indent = "  " * nesting
+        return f"{indent}- {text}"
+
+    return f"{prefix}{text}"
+
+
+def _table_to_md(table: dict) -> str:
+    """Convert a Google Docs table to markdown."""
+    rows = table.get("tableRows", [])
+    if not rows:
+        return ""
+
+    md_rows = []
+    for row in rows:
+        cells = row.get("tableCells", [])
+        cell_texts = []
+        for cell in cells:
+            cell_content = cell.get("content", [])
+            parts = [_structural_element_to_md(e) for e in cell_content]
+            cell_text = " ".join(p.strip() for p in parts if p.strip())
+            cell_texts.append(cell_text)
+        md_rows.append("| " + " | ".join(cell_texts) + " |")
+
+    if len(md_rows) >= 1:
+        # Add separator after header row
+        num_cols = md_rows[0].count("|") - 1
+        separator = "| " + " | ".join(["---"] * num_cols) + " |"
+        md_rows.insert(1, separator)
+
+    return "\n".join(md_rows)
+
+
+def extract_doc(doc_id: str) -> str:
+    """Extract a Google Doc as markdown."""
+    service = _build_service("docs", "v1")
+    doc = service.documents().get(documentId=doc_id).execute()
+
+    title = doc.get("title", "Untitled")
+    body = doc.get("body", {})
+    content = body.get("content", [])
+
+    parts = [f"# {title}", ""]
+    for element in content:
+        md = _structural_element_to_md(element)
+        if md:
+            parts.append(md)
+
+    return "\n".join(parts)
+
+
+def extract_sheet(sheet_id: str, sheet_name: str | None = None) -> str:
+    """Extract a Google Sheet as markdown."""
+    service = _build_service("sheets", "v4")
+
+    # Get spreadsheet metadata
+    spreadsheet = service.spreadsheets().get(spreadsheetId=sheet_id).execute()
+    title = spreadsheet.get("properties", {}).get("title", "Untitled")
+    sheets = spreadsheet.get("sheets", [])
+
+    if sheet_name:
+        target_sheets = [s for s in sheets if s["properties"]["title"] == sheet_name]
+        if not target_sheets:
+            available = [s["properties"]["title"] for s in sheets]
+            click.echo(f"Error: Sheet '{sheet_name}' not found. Available: {available}", err=True)
+            sys.exit(1)
+    else:
+        target_sheets = sheets
+
+    parts = [f"# {title}", ""]
+
+    for sheet_info in target_sheets:
+        tab_title = sheet_info["properties"]["title"]
+        range_name = f"'{tab_title}'"
+
+        result = (
+            service.spreadsheets().values().get(spreadsheetId=sheet_id, range=range_name).execute()
+        )
+
+        values = result.get("values", [])
+        if not values:
+            parts.append(f"## {tab_title}")
+            parts.append("*(empty)*")
+            parts.append("")
+            continue
+
+        parts.append(f"## {tab_title}")
+        parts.append("")
+
+        # Normalize row lengths
+        max_cols = max(len(row) for row in values)
+        normalized = [row + [""] * (max_cols - len(row)) for row in values]
+
+        # First row as header
+        header = normalized[0]
+        parts.append("| " + " | ".join(str(c) for c in header) + " |")
+        parts.append("| " + " | ".join(["---"] * max_cols) + " |")
+
+        for row in normalized[1:]:
+            parts.append("| " + " | ".join(str(c) for c in row) + " |")
+
+        parts.append("")
+
+    return "\n".join(parts)
+
+
+def parse_doc_id(doc_id_or_url: str) -> str:
+    """Parse a document ID from a URL or raw ID."""
+    return _extract_doc_id(doc_id_or_url)
+
+
+@click.group()
+def cli():
+    """Extract content from Google Docs and Sheets."""
+    pass
+
+
+@cli.command()
+@click.argument("doc_id")
+@click.option("--output", "-o", type=click.Path(), help="Output file path (default: stdout)")
+def doc(doc_id: str, output: str | None) -> None:
+    """Extract a Google Doc as markdown."""
+    doc_id = parse_doc_id(doc_id)
+    md = extract_doc(doc_id)
+    if output:
+        Path(output).write_text(md)
+        click.echo(f"Saved to {output}")
+    else:
+        click.echo(md)
+
+
+@cli.command()
+@click.argument("sheet_id")
+@click.option("--output", "-o", type=click.Path(), help="Output file path (default: stdout)")
+@click.option("--sheet-name", "-s", help="Extract a specific sheet tab")
+def sheet(sheet_id: str, output: str | None, sheet_name: str | None) -> None:
+    """Extract a Google Sheet as markdown."""
+    sheet_id = parse_doc_id(sheet_id)
+    md = extract_sheet(sheet_id, sheet_name)
+    if output:
+        Path(output).write_text(md)
+        click.echo(f"Saved to {output}")
+    else:
+        click.echo(md)
+
+
+@cli.command()
+def check_auth() -> None:
+    """Check if Google API credentials are configured."""
+    creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
+    if not creds_path:
+        click.echo("GOOGLE_APPLICATION_CREDENTIALS: not set")
+        sys.exit(1)
+
+    if not Path(creds_path).exists():
+        click.echo(f"GOOGLE_APPLICATION_CREDENTIALS: {creds_path} (file not found)")
+        sys.exit(1)
+
+    try:
+        with open(creds_path) as f:
+            data = json.load(f)
+        email = data.get("client_email", "unknown")
+        project = data.get("project_id", "unknown")
+        click.echo(f"GOOGLE_APPLICATION_CREDENTIALS: {creds_path}")
+        click.echo(f"  Service account: {email}")
+        click.echo(f"  Project: {project}")
+        click.echo("  Status: OK (credentials file found)")
+        click.echo(f"\nShare your Google Docs/Sheets with: {email}")
+    except json.JSONDecodeError:
+        click.echo(f"GOOGLE_APPLICATION_CREDENTIALS: {creds_path} (invalid JSON)")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/unit/test_google_docs.py
+++ b/tests/unit/test_google_docs.py
@@ -1,0 +1,270 @@
+"""Tests for Google Docs importer skill."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+
+# Import the module under test
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "skills" / "google_docs" / "scripts"
+
+spec = importlib.util.spec_from_file_location("google_docs", SCRIPT_DIR / "google_docs.py")
+google_docs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(google_docs)
+
+
+class TestExtractDocId:
+    def test_raw_id(self):
+        assert google_docs._extract_doc_id("1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms") == (
+            "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+        )
+
+    def test_docs_url(self):
+        url = "https://docs.google.com/document/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit"
+        assert google_docs._extract_doc_id(url) == ("1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms")
+
+    def test_sheets_url(self):
+        url = "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit#gid=0"
+        assert google_docs._extract_doc_id(url) == ("1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms")
+
+    def test_docs_url_with_query_params(self):
+        url = "https://docs.google.com/document/d/abc123_-def/edit?usp=sharing"
+        assert google_docs._extract_doc_id(url) == "abc123_-def"
+
+    def test_short_id(self):
+        assert google_docs._extract_doc_id("abc123") == "abc123"
+
+
+class TestParagraphToMd:
+    def test_plain_text(self):
+        para = {
+            "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+            "elements": [{"textRun": {"content": "Hello world", "textStyle": {}}}],
+        }
+        assert google_docs._paragraph_to_md(para) == "Hello world"
+
+    def test_heading_1(self):
+        para = {
+            "paragraphStyle": {"namedStyleType": "HEADING_1"},
+            "elements": [{"textRun": {"content": "Title", "textStyle": {}}}],
+        }
+        assert google_docs._paragraph_to_md(para) == "# Title"
+
+    def test_heading_2(self):
+        para = {
+            "paragraphStyle": {"namedStyleType": "HEADING_2"},
+            "elements": [{"textRun": {"content": "Section", "textStyle": {}}}],
+        }
+        assert google_docs._paragraph_to_md(para) == "## Section"
+
+    def test_heading_3(self):
+        para = {
+            "paragraphStyle": {"namedStyleType": "HEADING_3"},
+            "elements": [{"textRun": {"content": "Subsection", "textStyle": {}}}],
+        }
+        assert google_docs._paragraph_to_md(para) == "### Subsection"
+
+    def test_bold_text(self):
+        para = {
+            "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+            "elements": [{"textRun": {"content": "bold", "textStyle": {"bold": True}}}],
+        }
+        result = google_docs._paragraph_to_md(para)
+        assert "**bold**" in result
+
+    def test_italic_text(self):
+        para = {
+            "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+            "elements": [{"textRun": {"content": "italic", "textStyle": {"italic": True}}}],
+        }
+        result = google_docs._paragraph_to_md(para)
+        assert "*italic*" in result
+
+    def test_link(self):
+        para = {
+            "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+            "elements": [
+                {
+                    "textRun": {
+                        "content": "click here",
+                        "textStyle": {"link": {"url": "https://example.com"}},
+                    }
+                }
+            ],
+        }
+        result = google_docs._paragraph_to_md(para)
+        assert "[click here](https://example.com)" in result
+
+    def test_empty_paragraph(self):
+        para = {
+            "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+            "elements": [{"textRun": {"content": "\n", "textStyle": {}}}],
+        }
+        assert google_docs._paragraph_to_md(para) == ""
+
+    def test_bullet_list(self):
+        para = {
+            "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+            "bullet": {"nestingLevel": 0},
+            "elements": [{"textRun": {"content": "item one", "textStyle": {}}}],
+        }
+        assert google_docs._paragraph_to_md(para) == "- item one"
+
+    def test_nested_bullet(self):
+        para = {
+            "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+            "bullet": {"nestingLevel": 2},
+            "elements": [{"textRun": {"content": "nested", "textStyle": {}}}],
+        }
+        assert google_docs._paragraph_to_md(para) == "    - nested"
+
+
+class TestTableToMd:
+    def test_simple_table(self):
+        table = {
+            "tableRows": [
+                {
+                    "tableCells": [
+                        {
+                            "content": [
+                                {
+                                    "paragraph": {
+                                        "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                                        "elements": [
+                                            {"textRun": {"content": "A", "textStyle": {}}}
+                                        ],
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "content": [
+                                {
+                                    "paragraph": {
+                                        "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                                        "elements": [
+                                            {"textRun": {"content": "B", "textStyle": {}}}
+                                        ],
+                                    }
+                                }
+                            ]
+                        },
+                    ]
+                },
+                {
+                    "tableCells": [
+                        {
+                            "content": [
+                                {
+                                    "paragraph": {
+                                        "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                                        "elements": [
+                                            {"textRun": {"content": "1", "textStyle": {}}}
+                                        ],
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "content": [
+                                {
+                                    "paragraph": {
+                                        "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                                        "elements": [
+                                            {"textRun": {"content": "2", "textStyle": {}}}
+                                        ],
+                                    }
+                                }
+                            ]
+                        },
+                    ]
+                },
+            ]
+        }
+        result = google_docs._table_to_md(table)
+        assert "| A | B |" in result
+        assert "| --- | --- |" in result
+        assert "| 1 | 2 |" in result
+
+    def test_empty_table(self):
+        assert google_docs._table_to_md({"tableRows": []}) == ""
+
+
+class TestStructuralElement:
+    def test_paragraph_element(self):
+        element = {
+            "paragraph": {
+                "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                "elements": [{"textRun": {"content": "text", "textStyle": {}}}],
+            }
+        }
+        assert google_docs._structural_element_to_md(element) == "text"
+
+    def test_section_break(self):
+        element = {"sectionBreak": {}}
+        assert "---" in google_docs._structural_element_to_md(element)
+
+    def test_unknown_element(self):
+        assert google_docs._structural_element_to_md({"unknown": {}}) == ""
+
+
+class TestCheckAuthCommand:
+    def test_missing_env_var(self):
+        runner = CliRunner()
+        env = {k: v for k, v in os.environ.items()}
+        env.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        result = runner.invoke(google_docs.cli, ["check-auth"], env=env)
+        assert result.exit_code != 0
+        assert "not set" in result.output
+
+    def test_file_not_found(self, tmp_path):
+        runner = CliRunner()
+        env = {k: v for k, v in os.environ.items()}
+        env["GOOGLE_APPLICATION_CREDENTIALS"] = str(tmp_path / "nonexistent.json")
+        result = runner.invoke(google_docs.cli, ["check-auth"], env=env)
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_valid_credentials_file(self, tmp_path):
+        creds = {
+            "type": "service_account",
+            "client_email": "test@project.iam.gserviceaccount.com",
+            "project_id": "my-project",
+        }
+        creds_file = tmp_path / "creds.json"
+        creds_file.write_text(json.dumps(creds))
+
+        runner = CliRunner()
+        env = {k: v for k, v in os.environ.items()}
+        env["GOOGLE_APPLICATION_CREDENTIALS"] = str(creds_file)
+        result = runner.invoke(google_docs.cli, ["check-auth"], env=env)
+        assert result.exit_code == 0
+        assert "test@project.iam.gserviceaccount.com" in result.output
+        assert "my-project" in result.output
+
+    def test_invalid_json(self, tmp_path):
+        creds_file = tmp_path / "bad.json"
+        creds_file.write_text("not json")
+
+        runner = CliRunner()
+        env = {k: v for k, v in os.environ.items()}
+        env["GOOGLE_APPLICATION_CREDENTIALS"] = str(creds_file)
+        result = runner.invoke(google_docs.cli, ["check-auth"], env=env)
+        assert result.exit_code != 0
+        assert "invalid JSON" in result.output
+
+
+class TestDocCommand:
+    def test_doc_help(self):
+        runner = CliRunner()
+        result = runner.invoke(google_docs.cli, ["doc", "--help"])
+        assert result.exit_code == 0
+        assert "DOC_ID" in result.output
+
+    def test_sheet_help(self):
+        runner = CliRunner()
+        result = runner.invoke(google_docs.cli, ["sheet", "--help"])
+        assert result.exit_code == 0
+        assert "SHEET_ID" in result.output


### PR DESCRIPTION
## Summary

- New `google_docs` skill to extract Google Docs and Sheets content as markdown
- Uses Google Cloud service account auth (`GOOGLE_APPLICATION_CREDENTIALS` env var) with read-only scopes
- Click CLI with `doc`, `sheet`, and `check-auth` subcommands
- Converts Google Docs structural elements (headings, bold, italic, links, bullets, tables) to markdown
- `google-api-python-client` added as optional extra (`uv sync --extra google`)
- 26 unit tests covering URL parsing, markdown conversion, and CLI commands
- README updated with skill entry, skill graph edge, and env var documentation

Fixes #62

## Test plan

- [x] All 238 tests pass (26 new + 212 existing)
- [x] Lint clean (ruff check + format)
- [x] Pre-commit hooks pass
- [ ] Human: set up service account and test with a real Google Doc
- [ ] Human: verify `check-auth` command shows correct service account info

🤖 Generated with [Claude Code](https://claude.com/claude-code)