### PR TITLE
Add march_madness skill with fetch_odds.py and tests

### DIFF
--- a/skills/march_madness/SKILL.md
+++ b/skills/march_madness/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: march_madness
+description: >
+  Fetch March Madness odds data from The Odds API. Use when the user asks
+  about March Madness odds, basketball futures, game lines, or wants to
+  refresh the odds data pipeline. Do NOT use for non-basketball sports.
+allowed-tools: Bash(uv run *)
+---
+
+Fetch and store NCAAB odds data for the March Madness model.
+
+## Commands
+
+```bash
+# Fetch men's championship futures
+uv run --directory SKILL_DIR python scripts/fetch_odds.py futures --output-dir OUTPUT_DIR
+
+# Fetch men's game odds (moneylines, spreads, totals)
+uv run --directory SKILL_DIR python scripts/fetch_odds.py game-odds --output-dir OUTPUT_DIR
+
+# Fetch everything
+uv run --directory SKILL_DIR python scripts/fetch_odds.py fetch-all --output-dir OUTPUT_DIR
+```
+
+`SKILL_DIR` = the skills repo root (where `pyproject.toml` lives).
+`OUTPUT_DIR` = where to write CSVs. Default: `~/claude/obsidian/knowledge_graph/March_Madness/data/`.
+
+## Environment
+
+Requires `ODDS_API_KEY` environment variable. Set in `~/.zshrc`:
+```bash
+export ODDS_API_KEY="your-key-here"
+```
+
+## Output Schemas
+
+### `mens_futures.csv`
+Wide format: one row per team, one column per bookmaker. American odds integers.
+```
+team_name,FanDuel,DraftKings,BetMGM,BetRivers,Caesars,Bet365,...
+```
+
+### `game_odds.csv`
+One row per team per game. American odds integers.
+```
+game_id,commence_time,team_name,is_home,h2h,spread_point,spread_price,total_point,total_over,total_under,bookmaker
+```
+
+### `odds_metadata.json`
+Credits used, timestamp, API response headers.
+
+## Sport Keys
+
+| Purpose | Sport Key |
+|---------|-----------|
+| Men's game odds | `basketball_ncaab` |
+| Men's championship futures | `basketball_ncaab_championship_winner` |
+| Women's game odds | `basketball_wncaab` (may be inactive) |
+| Women's futures | **Not available** via API — needs manual entry |
+
+## Credit Costs
+
+- Futures: 1 credit per pull
+- Game odds (3 markets): 3 credits per pull
+- Daily refresh for 4 weeks: ~112 credits total
+
+## Integration
+
+The madness repo (`zachmayer/madness`) reads these CSVs in `gambling.R`. It handles team name matching via `spell.csv` — this skill outputs team names as the API returns them.

--- a/skills/march_madness/scripts/fetch_odds.py
+++ b/skills/march_madness/scripts/fetch_odds.py
@@ -1,0 +1,198 @@
+"""Fetch NCAAB odds from The Odds API for March Madness modeling."""
+
+import csv
+import json
+import os
+import sys
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+
+import click
+import httpx
+
+BASE_URL = "https://api.the-odds-api.com/v4/sports"
+DEFAULT_OUTPUT_DIR = (
+    Path.home() / "claude" / "obsidian" / "knowledge_graph" / "March_Madness" / "data"
+)
+
+
+def get_api_key() -> str:
+    """Get API key from environment."""
+    key = os.environ.get("ODDS_API_KEY", "")
+    if not key:
+        click.echo("Error: ODDS_API_KEY environment variable not set.", err=True)
+        click.echo("Set it in ~/.zshrc: export ODDS_API_KEY='your-key'", err=True)
+        sys.exit(1)
+    return key
+
+
+def fetch(sport: str, markets: str = "h2h") -> tuple[list, dict]:
+    """Fetch odds from the API. Returns (data, metadata)."""
+    resp = httpx.get(
+        f"{BASE_URL}/{sport}/odds",
+        params={
+            "apiKey": get_api_key(),
+            "regions": "us",
+            "markets": markets,
+            "oddsFormat": "american",
+        },
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    metadata = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "sport": sport,
+        "markets": markets,
+        "credits_used": resp.headers.get("x-requests-last", "unknown"),
+        "credits_remaining": resp.headers.get("x-requests-remaining", "unknown"),
+    }
+    return resp.json(), metadata
+
+
+def parse_futures(data: list) -> list[dict]:
+    """Parse championship futures into wide format: one row per team, one column per bookmaker."""
+    team_odds: dict[str, dict[str, int | None]] = {}
+    all_bookmakers: set[str] = set()
+
+    for event in data:
+        for bk in event.get("bookmakers", []):
+            title = bk["title"]
+            all_bookmakers.add(title)
+            for market in bk.get("markets", []):
+                if market["key"] != "outrights":
+                    continue
+                for outcome in market["outcomes"]:
+                    team_odds.setdefault(outcome["name"], {})[title] = outcome.get("price")
+
+    sorted_bks = sorted(all_bookmakers)
+    return [
+        {"team_name": team, **{bk: team_odds[team].get(bk) for bk in sorted_bks}}
+        for team in sorted(team_odds)
+    ]
+
+
+def parse_game_odds(data: list) -> list[dict]:
+    """Parse game odds into long format: one row per team per game per bookmaker."""
+    rows = []
+    for event in data:
+        game_id = event["id"]
+        commence = event.get("commence_time", "")
+        home = event.get("home_team", "")
+        away = event.get("away_team", "")
+
+        for bk in event.get("bookmakers", []):
+            h2h: dict[str, int | None] = {}
+            spreads: dict[str, tuple[float | None, int | None]] = {}
+            totals: dict[str, float | int | None] = {}
+
+            for market in bk.get("markets", []):
+                for o in market["outcomes"]:
+                    if market["key"] == "h2h":
+                        h2h[o["name"]] = o.get("price")
+                    elif market["key"] == "spreads":
+                        spreads[o["name"]] = (o.get("point"), o.get("price"))
+                    elif market["key"] == "totals":
+                        totals["total_point"] = o.get("point")
+                        if o["name"] == "Over":
+                            totals["total_over"] = o.get("price")
+                        elif o["name"] == "Under":
+                            totals["total_under"] = o.get("price")
+
+            for team in [home, away]:
+                sp = spreads.get(team, (None, None))
+                rows.append(
+                    {
+                        "game_id": game_id,
+                        "commence_time": commence,
+                        "team_name": team,
+                        "is_home": team == home,
+                        "bookmaker": bk["title"],
+                        "h2h": h2h.get(team),
+                        "spread_point": sp[0],
+                        "spread_price": sp[1],
+                        **totals,
+                    }
+                )
+    return rows
+
+
+def write_csv(rows: list[dict], path: Path) -> None:
+    """Write rows to CSV."""
+    if not rows:
+        click.echo(f"  No data to write to {path}")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    click.echo(f"  Wrote {len(rows)} rows to {path}")
+
+
+def save_metadata(out: Path, key: str, metadata: dict) -> None:
+    """Merge metadata into odds_metadata.json."""
+    meta_path = out / "odds_metadata.json"
+    existing = json.loads(meta_path.read_text()) if meta_path.exists() else {}
+    existing[key] = metadata
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(json.dumps(existing, indent=2))
+    click.echo(
+        f"  Credits used: {metadata['credits_used']}, remaining: {metadata['credits_remaining']}"
+    )
+
+
+def save_raw_json(data: list, path: Path) -> None:
+    """Optionally save raw API JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+    click.echo(f"  Raw JSON: {path}")
+
+
+@click.group()
+def cli():
+    """Fetch NCAAB odds from The Odds API."""
+    pass
+
+
+@cli.command()
+@click.option("--output-dir", type=click.Path(), default=str(DEFAULT_OUTPUT_DIR))
+@click.option("--json-raw", is_flag=True, help="Also save raw API JSON")
+def futures(output_dir: str, json_raw: bool):
+    """Fetch men's championship futures odds."""
+    out = Path(output_dir)
+    click.echo("Fetching men's championship futures...")
+    data, metadata = fetch("basketball_ncaab_championship_winner", markets="outrights")
+    write_csv(parse_futures(data), out / "mens_futures.csv")
+    if json_raw:
+        save_raw_json(data, out / "mens_futures_raw.json")
+    save_metadata(out, "futures", metadata)
+
+
+@cli.command("game-odds")
+@click.option("--output-dir", type=click.Path(), default=str(DEFAULT_OUTPUT_DIR))
+@click.option("--json-raw", is_flag=True, help="Also save raw API JSON")
+def game_odds(output_dir: str, json_raw: bool):
+    """Fetch men's game odds (moneylines, spreads, totals)."""
+    out = Path(output_dir)
+    click.echo("Fetching men's game odds (h2h, spreads, totals)...")
+    data, metadata = fetch("basketball_ncaab", markets="h2h,spreads,totals")
+    write_csv(parse_game_odds(data), out / "game_odds.csv")
+    if json_raw:
+        save_raw_json(data, out / "game_odds_raw.json")
+    save_metadata(out, "game_odds", metadata)
+
+
+@cli.command("fetch-all")
+@click.option("--output-dir", type=click.Path(), default=str(DEFAULT_OUTPUT_DIR))
+@click.option("--json-raw", is_flag=True, help="Also save raw API JSON")
+@click.pass_context
+def fetch_all(ctx: click.Context, output_dir: str, json_raw: bool):
+    """Fetch all available odds data."""
+    ctx.invoke(futures, output_dir=output_dir, json_raw=json_raw)
+    click.echo()
+    ctx.invoke(game_odds, output_dir=output_dir, json_raw=json_raw)
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/unit/test_fetch_odds.py
+++ b/tests/unit/test_fetch_odds.py
@@ -1,0 +1,330 @@
+"""Tests for march_madness fetch_odds.py parsing and CLI."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+# Import fetch_odds.py from the skill directory
+_spec = importlib.util.spec_from_file_location(
+    "fetch_odds",
+    Path(__file__).resolve().parents[2] / "skills" / "march_madness" / "scripts" / "fetch_odds.py",
+)
+assert _spec is not None and _spec.loader is not None
+fetch_odds = importlib.util.module_from_spec(_spec)
+sys.modules["fetch_odds"] = fetch_odds
+_spec.loader.exec_module(fetch_odds)
+
+
+SAMPLE_FUTURES = [
+    {
+        "id": "abc123",
+        "sport_key": "basketball_ncaab_championship_winner",
+        "commence_time": "2026-04-07T00:00:00Z",
+        "bookmakers": [
+            {
+                "key": "fanduel",
+                "title": "FanDuel",
+                "markets": [
+                    {
+                        "key": "outrights",
+                        "outcomes": [
+                            {"name": "Duke Blue Devils", "price": 600},
+                            {"name": "Houston Cougars", "price": 800},
+                            {"name": "Auburn Tigers", "price": 1000},
+                        ],
+                    }
+                ],
+            },
+            {
+                "key": "draftkings",
+                "title": "DraftKings",
+                "markets": [
+                    {
+                        "key": "outrights",
+                        "outcomes": [
+                            {"name": "Duke Blue Devils", "price": 550},
+                            {"name": "Houston Cougars", "price": 850},
+                        ],
+                    }
+                ],
+            },
+        ],
+    }
+]
+
+SAMPLE_GAME_ODDS = [
+    {
+        "id": "game1",
+        "sport_key": "basketball_ncaab",
+        "commence_time": "2026-02-15T00:00:00Z",
+        "home_team": "Duke Blue Devils",
+        "away_team": "North Carolina Tar Heels",
+        "bookmakers": [
+            {
+                "key": "fanduel",
+                "title": "FanDuel",
+                "markets": [
+                    {
+                        "key": "h2h",
+                        "outcomes": [
+                            {"name": "Duke Blue Devils", "price": -180},
+                            {"name": "North Carolina Tar Heels", "price": 150},
+                        ],
+                    },
+                    {
+                        "key": "spreads",
+                        "outcomes": [
+                            {"name": "Duke Blue Devils", "price": -110, "point": -4.5},
+                            {"name": "North Carolina Tar Heels", "price": -110, "point": 4.5},
+                        ],
+                    },
+                    {
+                        "key": "totals",
+                        "outcomes": [
+                            {"name": "Over", "price": -110, "point": 152.5},
+                            {"name": "Under", "price": -110, "point": 152.5},
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+]
+
+
+class TestParseFutures:
+    """Test parse_futures function."""
+
+    def test_basic_parsing(self) -> None:
+        rows = fetch_odds.parse_futures(SAMPLE_FUTURES)
+        assert len(rows) == 3
+
+    def test_team_names_sorted(self) -> None:
+        rows = fetch_odds.parse_futures(SAMPLE_FUTURES)
+        names = [r["team_name"] for r in rows]
+        assert names == ["Auburn Tigers", "Duke Blue Devils", "Houston Cougars"]
+
+    def test_wide_format_uses_api_title(self) -> None:
+        rows = fetch_odds.parse_futures(SAMPLE_FUTURES)
+        duke = next(r for r in rows if r["team_name"] == "Duke Blue Devils")
+        assert duke["FanDuel"] == 600
+        assert duke["DraftKings"] == 550
+
+    def test_missing_bookmaker_is_none(self) -> None:
+        rows = fetch_odds.parse_futures(SAMPLE_FUTURES)
+        auburn = next(r for r in rows if r["team_name"] == "Auburn Tigers")
+        assert auburn["FanDuel"] == 1000
+        assert auburn["DraftKings"] is None
+
+    def test_empty_data(self) -> None:
+        assert fetch_odds.parse_futures([]) == []
+
+    def test_ignores_non_outright_markets(self) -> None:
+        data = [
+            {
+                "bookmakers": [
+                    {
+                        "title": "FanDuel",
+                        "markets": [
+                            {
+                                "key": "h2h",
+                                "outcomes": [{"name": "Team A", "price": 100}],
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+        rows = fetch_odds.parse_futures(data)
+        assert rows == []
+
+
+class TestParseGameOdds:
+    """Test parse_game_odds function."""
+
+    def test_row_count(self) -> None:
+        rows = fetch_odds.parse_game_odds(SAMPLE_GAME_ODDS)
+        assert len(rows) == 2
+
+    def test_team_names(self) -> None:
+        rows = fetch_odds.parse_game_odds(SAMPLE_GAME_ODDS)
+        assert {r["team_name"] for r in rows} == {"Duke Blue Devils", "North Carolina Tar Heels"}
+
+    def test_h2h(self) -> None:
+        rows = fetch_odds.parse_game_odds(SAMPLE_GAME_ODDS)
+        duke = next(r for r in rows if r["team_name"] == "Duke Blue Devils")
+        assert duke["h2h"] == -180
+
+    def test_spreads(self) -> None:
+        rows = fetch_odds.parse_game_odds(SAMPLE_GAME_ODDS)
+        duke = next(r for r in rows if r["team_name"] == "Duke Blue Devils")
+        assert duke["spread_point"] == -4.5
+        assert duke["spread_price"] == -110
+
+    def test_totals_are_game_level(self) -> None:
+        rows = fetch_odds.parse_game_odds(SAMPLE_GAME_ODDS)
+        for row in rows:
+            assert row["total_point"] == 152.5
+
+    def test_home_away(self) -> None:
+        rows = fetch_odds.parse_game_odds(SAMPLE_GAME_ODDS)
+        duke = next(r for r in rows if r["team_name"] == "Duke Blue Devils")
+        unc = next(r for r in rows if r["team_name"] == "North Carolina Tar Heels")
+        assert duke["is_home"] is True
+        assert unc["is_home"] is False
+
+    def test_bookmaker_uses_api_title(self) -> None:
+        rows = fetch_odds.parse_game_odds(SAMPLE_GAME_ODDS)
+        assert all(r["bookmaker"] == "FanDuel" for r in rows)
+
+    def test_empty_data(self) -> None:
+        assert fetch_odds.parse_game_odds([]) == []
+
+    def test_multiple_bookmakers(self) -> None:
+        data = [
+            {
+                "id": "g1",
+                "commence_time": "2026-02-15T00:00:00Z",
+                "home_team": "Team A",
+                "away_team": "Team B",
+                "bookmakers": [
+                    {
+                        "key": "bk1",
+                        "title": "Book1",
+                        "markets": [
+                            {
+                                "key": "h2h",
+                                "outcomes": [
+                                    {"name": "Team A", "price": -150},
+                                    {"name": "Team B", "price": 130},
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "key": "bk2",
+                        "title": "Book2",
+                        "markets": [
+                            {
+                                "key": "h2h",
+                                "outcomes": [
+                                    {"name": "Team A", "price": -140},
+                                    {"name": "Team B", "price": 120},
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+        rows = fetch_odds.parse_game_odds(data)
+        assert len(rows) == 4  # 2 teams * 2 bookmakers
+
+
+class TestWriteCsv:
+    """Test write_csv function."""
+
+    def test_writes_csv(self, tmp_path: Path) -> None:
+        rows = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        out = tmp_path / "test.csv"
+        fetch_odds.write_csv(rows, out)
+        content = out.read_text()
+        assert "a,b" in content
+        assert "1,2" in content
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        rows = [{"x": 1}]
+        out = tmp_path / "sub" / "dir" / "test.csv"
+        fetch_odds.write_csv(rows, out)
+        assert out.exists()
+
+    def test_empty_rows_no_file(self, tmp_path: Path) -> None:
+        out = tmp_path / "empty.csv"
+        fetch_odds.write_csv([], out)
+        assert not out.exists()
+
+
+class TestCLIMissingApiKey:
+    """Test CLI behavior when ODDS_API_KEY is not set."""
+
+    def test_futures_missing_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ODDS_API_KEY", raising=False)
+        result = CliRunner().invoke(fetch_odds.cli, ["futures"])
+        assert result.exit_code != 0
+
+    def test_game_odds_missing_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ODDS_API_KEY", raising=False)
+        result = CliRunner().invoke(fetch_odds.cli, ["game-odds"])
+        assert result.exit_code != 0
+
+    def test_fetch_all_missing_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ODDS_API_KEY", raising=False)
+        result = CliRunner().invoke(fetch_odds.cli, ["fetch-all"])
+        assert result.exit_code != 0
+
+
+class TestCLIWithMockedApi:
+    """Test CLI commands with mocked API calls."""
+
+    def _mock_response(self, data: list, status_code: int = 200) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = data
+        resp.headers = {
+            "x-requests-last": "1",
+            "x-requests-remaining": "499",
+        }
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_futures_success(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+        mock_resp = self._mock_response(SAMPLE_FUTURES)
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = CliRunner().invoke(fetch_odds.cli, ["futures", "--output-dir", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert (tmp_path / "mens_futures.csv").exists()
+
+    def test_game_odds_success(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+        mock_resp = self._mock_response(SAMPLE_GAME_ODDS)
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = CliRunner().invoke(
+                fetch_odds.cli, ["game-odds", "--output-dir", str(tmp_path)]
+            )
+
+        assert result.exit_code == 0
+        assert (tmp_path / "game_odds.csv").exists()
+
+    def test_fetch_all_success(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("ODDS_API_KEY", "test-key")
+
+        futures_resp = self._mock_response(SAMPLE_FUTURES)
+        game_resp = self._mock_response(SAMPLE_GAME_ODDS)
+
+        call_count = 0
+
+        def mock_get(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            url = args[0] if args else kwargs.get("url", "")
+            if "championship_winner" in url:
+                return futures_resp
+            return game_resp
+
+        with patch("httpx.get", side_effect=mock_get):
+            result = CliRunner().invoke(
+                fetch_odds.cli, ["fetch-all", "--output-dir", str(tmp_path)]
+            )
+
+        assert result.exit_code == 0
+        assert (tmp_path / "mens_futures.csv").exists()
+        assert (tmp_path / "game_odds.csv").exists()


### PR DESCRIPTION
Fixes #93

## Summary

- Adds `march_madness` skill with `SKILL.md` and `fetch_odds.py` Click CLI
- `fetch_odds.py` fetches NCAAB odds from The Odds API (futures + game odds)
- 24 unit tests covering parse_futures, parse_game_odds, write_csv, and CLI commands
- Documentation in obsidian (`Recurring_Odds_Refresh.md`) describes the recurring refresh pattern

## Acceptance Criteria Status

| AC | Status | Notes |
|----|--------|-------|
| 1. Document in obsidian | Done | `Recurring_Odds_Refresh.md` in knowledge_graph/Technical/ |
| 2. Document recurring pattern | Done | Pattern: heartbeat picks up issue, runs fetch-all, commits to vault |
| 3. Test run of fetch-all | **Blocked** | `ODDS_API_KEY` not set in environment |
| 4. Verify output sizes | **Blocked** | Depends on AC #3 |
| 5. Credits <=5 per run | N/A | Script uses 2 API calls per fetch-all |

## Blocker

AC #3 and #4 require `ODDS_API_KEY` to be set. To unblock:

```bash
# Get free key at https://the-odds-api.com (500 requests/month free tier)
echo 'export ODDS_API_KEY="your-key-here"' >> ~/.zshrc
source ~/.zshrc
# Then run manually or let heartbeat pick it up:
uv run python skills/march_madness/scripts/fetch_odds.py fetch-all
```

## Test plan

- [x] `uv run pytest tests/unit/test_fetch_odds.py` — 24 passed
- [x] Full suite — 292 passed, 20 skipped
- [ ] Live test with `ODDS_API_KEY` set (manual step needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)