### PR TITLE
Add in-progress label to heartbeat issue claiming

### DIFF
--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -5,7 +5,7 @@ description: >
   work on GitHub Issues, create PRs, and maintain the obsidian vault. Use when
   the user wants autonomous periodic task processing or asks about running
   Claude on a schedule. Do NOT use for one-time tasks or interactive work.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git status), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *), Bash(git push *), Bash(git pull *), Bash(git fetch *), Bash(git -C *), Bash(git worktree *), Bash(gh pr create *), Bash(gh pr view *), Bash(gh pr list *), Bash(ls *), Bash(mkdir *), Bash(date *), Bash(uv run python *)
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git status), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *), Bash(git push *), Bash(git pull *), Bash(git fetch *), Bash(git -C *), Bash(git worktree *), Bash(gh pr create *), Bash(gh pr view *), Bash(gh pr list *), Bash(gh issue edit *), Bash(ls *), Bash(mkdir *), Bash(date *), Bash(uv run python *)
 ---
 
 You are the heartbeat agent. The runner (heartbeat.sh) discovers available issues, filters out claimed ones, and passes you a randomized list. Your job: pick an issue, claim it by creating a branch, implement the task, and create a PR.
@@ -26,9 +26,10 @@ You are the heartbeat agent. The runner (heartbeat.sh) discovers available issue
 
 ```bash
 git checkout -b heartbeat/issue-N
+gh issue edit N --repo OWNER/REPO --add-label in-progress
 ```
 
-If this fails, the issue is already claimed by another agent. **Pick a different issue and try again.**
+If `git checkout -b` fails, the issue is already claimed by another agent. **Pick a different issue and try again.** The `in-progress` label prevents other agents from picking up the same issue in future cycles (the runner filters it out).
 
 Then implement the task, commit, push, and open a PR:
 


### PR DESCRIPTION
## Summary

- Heartbeat runner now filters out issues labeled `in-progress`, preventing re-pickup after PR close/branch deletion
- Agent is instructed to apply `in-progress` label immediately after claiming an issue via `gh issue edit`
- Added `Bash(gh issue edit *)` to allowed tools in both `heartbeat.sh` and `SKILL.md`

## Problem

The heartbeat used git branches (`heartbeat/issue-N`) as the sole coordination mechanism. Once a PR was closed/merged and the branch deleted, the issue became eligible for pickup again — leading to duplicate work on issues that need human design direction (e.g. #59 was picked up by #117, closed, then could be picked up again).

## Changes

| File | Change |
|------|--------|
| `heartbeat.sh` | Fetch `labels` in issue JSON, filter out `in-progress` in python step, add `gh issue edit` to allowed tools, instruct agent to label after claiming |
| `SKILL.md` | Add `gh issue edit *` to allowed-tools, update claim instructions with label step |

## Test plan

- [x] 261 tests pass, lint clean
- [x] Verified `in-progress` label exists on repo
- [ ] Next heartbeat cycle should skip `in-progress` issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)