### PR TITLE
Scavenge stale in-progress labels in heartbeat

### DIFF
--- a/skills/heartbeat/scripts/heartbeat.sh
+++ b/skills/heartbeat/scripts/heartbeat.sh
@@ -3,9 +3,12 @@
 # Designed for macOS launchd user agent execution.
 #
 # PARALLEL BY DESIGN: Multiple heartbeat instances may run concurrently on the
-# same machine. Each gets its own worktree. Coordination uses git branches as
-# atomic claims — `git checkout -b heartbeat/issue-N` either succeeds (claimed)
-# or fails (another agent got it first). No locking, no label-based claiming.
+# same machine. Each gets its own worktree. Two coordination mechanisms:
+#   1. Git branches as atomic claims — `git checkout -b heartbeat/issue-N`
+#      either succeeds (claimed) or fails (another agent got it first).
+#   2. `in-progress` label — applied after claiming, survives branch deletion.
+#      Scavenged automatically: if an issue has the label but no branch and
+#      no open PR, the label is removed so the issue can be re-picked.
 # The agent receives a randomized list of available issues and picks one.
 set -euo pipefail
 
@@ -104,17 +107,29 @@ for candidate in $SHUFFLED_REPOS; do
     EXISTING_BRANCHES=$(git -C "$candidate_dir" ls-remote --heads origin 'refs/heads/heartbeat/issue-*' 2>/dev/null \
         | awk '{print $2}' | sed 's|refs/heads/heartbeat/issue-||' || echo "")
 
-    # Filter out claimed issues (existing branches) and in-progress issues, then randomize
-    # EXISTING_BRANCHES passed via env var (not interpolated into source) to prevent injection
-    AVAILABLE_ISSUES=$(echo "$ALL_ISSUES" | EXISTING="$EXISTING_BRANCHES" python3 -c "
-import sys, json, random, os
+    # Scavenge stale in-progress labels then filter. An in-progress issue is
+    # stale if it has no heartbeat branch on origin AND no open PR. Stale labels
+    # are removed (so the issue is available this cycle and future ones).
+    OPEN_PRS=$(gh pr list --repo "$candidate" --state open --json headRefName --limit 100 2>/dev/null || echo "[]")
+    AVAILABLE_ISSUES=$(echo "$ALL_ISSUES" | EXISTING="$EXISTING_BRANCHES" OPEN_PRS="$OPEN_PRS" REPO="$candidate" python3 -c "
+import sys, json, random, os, subprocess
 issues = json.loads(sys.stdin.read())
 existing = set(line.strip() for line in os.environ.get('EXISTING', '').strip().split('\n') if line.strip())
-available = [
-    i for i in issues
-    if str(i['number']) not in existing
-    and 'in-progress' not in {l['name'] for l in i.get('labels', [])}
-]
+open_pr_branches = {pr['headRefName'] for pr in json.loads(os.environ.get('OPEN_PRS', '[]'))}
+repo = os.environ['REPO']
+available = []
+for i in issues:
+    num = str(i['number'])
+    if num in existing:
+        continue
+    labels = {l['name'] for l in i.get('labels', [])}
+    if 'in-progress' in labels:
+        branch_name = f'heartbeat/issue-{num}'
+        if branch_name in open_pr_branches:
+            continue  # legitimately in progress — has open PR
+        # Stale label: no branch, no open PR. Remove and make available.
+        subprocess.run(['gh', 'issue', 'edit', num, '--repo', repo, '--remove-label', 'in-progress'], capture_output=True)
+    available.append(i)
 random.shuffle(available)
 print(json.dumps(available))
 ")


### PR DESCRIPTION
## Summary

- Fixes the roach motel from #135: `in-progress` labels are now automatically removed when stale
- Updates header comment to accurately describe the dual coordination mechanism

## Problem

PR #135 added `in-progress` labels but never removed them. If the agent crashed, timed out, or the PR was rejected, the issue got permanently stuck with `in-progress` — worse than the original duplicate-pickup bug.

## Fix

The runner now scavenges before filtering. For each `in-progress` issue, it checks:
1. Is there a `heartbeat/issue-N` branch on origin? → still claimed, skip
2. Is there an open PR from that branch? → still in review, skip
3. Neither? → stale label, remove it and make the issue available

This runs every cycle (15 min), so stale labels are cleaned up quickly.

## Test plan

- [x] 261 tests pass, lint clean
- [x] Logic review: scavenge correctly handles all lifecycle states
- [ ] Next heartbeat cycle with a stale `in-progress` issue should auto-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)