### PR TITLE
Add flat-file skill format with normalization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ make upgrade        # Upgrade all dependencies
 
 ## Creating a New Skill
 
-Each skill is a directory under `skills/` with a `SKILL.md` file:
+Skills support two formats: **directory** (for skills with scripts or multiple files) and **flat-file** (for prompt-only skills).
+
+### Directory format
 
 ```
 skills/my_skill/
@@ -174,7 +176,17 @@ skills/my_skill/
     └── my_script.py
 ```
 
-The `SKILL.md` format:
+### Flat-file format
+
+Prompt-only skills (no `scripts/`) can be a single file:
+
+```
+skills/my_skill.md     # Same YAML frontmatter + markdown content
+```
+
+The flat-file format is equivalent to `skills/my_skill/SKILL.md` — just less boilerplate for simple skills. Run `uv run python scripts/normalize_skills.py` to convert flat files into directory format (e.g. before install). Use `--dry-run` to preview.
+
+### SKILL.md format
 
 ```yaml
 ---

--- a/scripts/normalize_skills.py
+++ b/scripts/normalize_skills.py
@@ -1,0 +1,41 @@
+"""Normalize flat-file skills (skills/<name>.md) into directory format (skills/<name>/SKILL.md)."""
+
+from pathlib import Path
+
+import click
+
+
+@click.command()
+@click.option(
+    "--skills-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default="skills",
+    help="Skills directory to normalize.",
+)
+@click.option("--dry-run", is_flag=True, help="Show what would be done without making changes.")
+def normalize(skills_dir: Path, dry_run: bool) -> None:
+    """Convert flat-file skills into name/SKILL.md directories."""
+    flat_files = sorted(f for f in skills_dir.glob("*.md") if f.is_file())
+
+    if not flat_files:
+        click.echo("No flat-file skills found.")
+        return
+
+    for flat_file in flat_files:
+        name = flat_file.stem
+        target_dir = skills_dir / name
+
+        if target_dir.exists():
+            click.echo(f"  SKIP {flat_file.name} — {name}/ already exists")
+            continue
+
+        if dry_run:
+            click.echo(f"  WOULD {flat_file.name} → {name}/SKILL.md")
+        else:
+            target_dir.mkdir()
+            flat_file.rename(target_dir / "SKILL.md")
+            click.echo(f"  {flat_file.name} → {name}/SKILL.md")
+
+
+if __name__ == "__main__":
+    normalize()

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -1,0 +1,81 @@
+"""Test the normalize_skills.py script."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "normalize_skills.py"
+
+SAMPLE_FLAT_SKILL = """\
+---
+name: my_test_skill
+description: >
+  Use when testing normalization. Do NOT use in production.
+---
+
+This is a test skill.
+"""
+
+
+def test_normalize_creates_directory(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    flat_file = skills_dir / "my_test_skill.md"
+    flat_file.write_text(SAMPLE_FLAT_SKILL)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--skills-dir", str(skills_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (skills_dir / "my_test_skill" / "SKILL.md").exists()
+    assert not flat_file.exists()
+    assert (skills_dir / "my_test_skill" / "SKILL.md").read_text() == SAMPLE_FLAT_SKILL
+
+
+def test_normalize_skips_existing_directory(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "my_test_skill").mkdir()
+    (skills_dir / "my_test_skill" / "SKILL.md").write_text("existing")
+    flat_file = skills_dir / "my_test_skill.md"
+    flat_file.write_text(SAMPLE_FLAT_SKILL)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--skills-dir", str(skills_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert flat_file.exists()  # flat file NOT consumed
+    assert (skills_dir / "my_test_skill" / "SKILL.md").read_text() == "existing"
+
+
+def test_normalize_dry_run(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    flat_file = skills_dir / "my_test_skill.md"
+    flat_file.write_text(SAMPLE_FLAT_SKILL)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--skills-dir", str(skills_dir), "--dry-run"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert flat_file.exists()  # still there
+    assert not (skills_dir / "my_test_skill").exists()  # not created
+
+
+def test_normalize_no_flat_files(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--skills-dir", str(skills_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "No flat-file skills found" in result.stdout

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -7,6 +7,7 @@ import pytest
 
 SKILLS_DIR = Path(__file__).resolve().parents[2] / "skills"
 SKILL_DIRS = sorted(d for d in SKILLS_DIR.iterdir() if d.is_dir() and d.name != "__pycache__")
+FLAT_SKILLS = sorted(f for f in SKILLS_DIR.glob("*.md") if f.is_file())
 
 
 @pytest.fixture(params=[d.name for d in SKILL_DIRS], ids=lambda n: n)
@@ -66,3 +67,49 @@ class TestSkillStructure:
         assert "allowed-tools" in post.metadata, (
             f"{skill_dir.name}: has scripts/ but no 'allowed-tools' in frontmatter"
         )
+
+
+if FLAT_SKILLS:
+
+    @pytest.fixture(params=[f.stem for f in FLAT_SKILLS], ids=lambda n: f"flat:{n}")
+    def flat_skill(request: pytest.FixtureRequest) -> Path:
+        return SKILLS_DIR / f"{request.param}.md"
+
+    class TestFlatSkillStructure:
+        """Validate flat-file skills (skills/<name>.md)."""
+
+        def test_valid_frontmatter(self, flat_skill: Path) -> None:
+            text = flat_skill.read_text()
+            post = frontmatter.loads(text)
+            assert "name" in post.metadata, "frontmatter missing 'name'"
+            assert "description" in post.metadata, "frontmatter missing 'description'"
+
+        def test_name_matches_filename(self, flat_skill: Path) -> None:
+            text = flat_skill.read_text()
+            post = frontmatter.loads(text)
+            assert post.metadata.get("name") == flat_skill.stem, (
+                f"name '{post.metadata.get('name')}' doesn't match filename '{flat_skill.stem}'"
+            )
+
+        def test_description_not_empty(self, flat_skill: Path) -> None:
+            text = flat_skill.read_text()
+            post = frontmatter.loads(text)
+            desc = post.metadata.get("description", "").strip()
+            assert len(desc) > 20, "description too short — should explain when to use"
+
+        def test_snake_case_name(self, flat_skill: Path) -> None:
+            name = flat_skill.stem
+            assert name == name.lower(), "filename must be lowercase"
+            assert " " not in name, "filename must not contain spaces"
+            assert name.replace("-", "").replace("_", "").isalnum(), (
+                "filename must be alphanumeric with hyphens/underscores"
+            )
+
+        def test_description_uses_standard_pattern(self, flat_skill: Path) -> None:
+            text = flat_skill.read_text()
+            post = frontmatter.loads(text)
+            desc = post.metadata.get("description", "")
+            assert "WHEN:" not in desc and "WHEN NOT:" not in desc, (
+                f"{flat_skill.stem}: description uses 'WHEN:/WHEN NOT:' pattern — "
+                "use 'Use when'/'Do NOT use' instead for consistency"
+            )


### PR DESCRIPTION
Fixes #48

## Summary

- **`scripts/normalize_skills.py`** — Click CLI that converts `skills/<name>.md` flat files into `skills/<name>/SKILL.md` directory format. Supports `--dry-run` and `--skills-dir` options.
- **`tests/unit/test_normalize.py`** — Tests for the normalize script (create, skip existing, dry-run, no-op).
- **`tests/unit/test_skills.py`** — Extended to discover and validate flat-file skills with the same frontmatter rules as directory skills.
- **`README.md`** — Documents both formats under "Creating a New Skill".

## Makefile integration (human TODO)

The heartbeat agent cannot modify the Makefile. To wire the normalize step into `make install-local`, add before the symlink loop:

```makefile
@uv run python scripts/normalize_skills.py --skills-dir $(SKILLS_DIR)
```

For `npx skills`, the external tool can call the same script.

## Test plan

- [x] All existing tests pass (173 passed, 20 skipped)
- [x] Normalize script tests cover: create directory, skip existing, dry-run, no flat files
- [ ] Verify `uv run python scripts/normalize_skills.py --dry-run` works with a flat-file skill
- [ ] Wire into Makefile (human)

🤖 Generated with [Claude Code](https://claude.com/claude-code)