### PR TITLE
Force Sonnet 4.6 for all subagents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "env": {
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6"
+  },
   "permissions": {
     "allow": [
       "Read(**)",

--- a/settings.template.json
+++ b/settings.template.json
@@ -1,4 +1,8 @@
 {
+  "env": {
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6"
+  },
   "permissions": {
     "allow": [
       "Bash(echo *)",


### PR DESCRIPTION
Fixes #165

## Summary
- Add `ANTHROPIC_DEFAULT_HAIKU_MODEL` and `ANTHROPIC_DEFAULT_SONNET_MODEL` env vars to settings
- Both set to `claude-sonnet-4-6`, overriding Haiku for all explore subagents
- Applied to `settings.template.json` (global, installed via `make install-local`) and `.claude/settings.json` (project)

## Test plan
- [x] 298 tests pass, 0 failures
- [x] Lint clean (pre-commit)
- [x] Both JSON files validated
- [ ] After merge: run `make install-local` to apply to `~/.claude/settings.json`