### PR TITLE
Add issue_curator skill for Tier 4 issue curation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Skills are grouped by their role in the capture → organize → process pipelin
 | [daily_briefing](skills/daily_briefing/) | Prompt | Morning summary from memory, tasks, and vault |
 | [reminders](skills/reminders/) | Prompt | Time-aware reminders stored as markdown checklist in obsidian |
 | [evergreen](skills/evergreen/) | Prompt | Periodic vault and repo housekeeping: orphan notes, broken links, stale branches |
+| [issue_curator](skills/issue_curator/) | Prompt | Curate GitHub issues: merge duplicates, close infeasible, improve descriptions |
 | [session_planner](skills/session_planner/) | Prompt | Plan a focused work session from memory, tasks, and context |
 
 ### Process
@@ -116,6 +117,7 @@ graph LR
     remember_session --> obsidian
     heartbeat --> hierarchical_memory
     heartbeat --> obsidian
+    heartbeat --> issue_curator
     heartbeat --> reminders
     heartbeat --> daily_briefing
     heartbeat --> evergreen

--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -5,7 +5,7 @@ description: >
   work on GitHub Issues, create PRs, and maintain the obsidian vault. Use when
   the user wants autonomous periodic task processing or asks about running
   Claude on a schedule. Do NOT use for one-time tasks or interactive work.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git status), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *), Bash(git push *), Bash(git pull *), Bash(git fetch *), Bash(git -C *), Bash(git worktree *), Bash(gh pr create *), Bash(gh pr view *), Bash(gh pr list *), Bash(gh pr diff *), Bash(gh pr edit *), Bash(gh api *), Bash(gh issue edit *), Bash(gh issue close *), Bash(gh issue comment *), Bash(ls *), Bash(mkdir *), Bash(date *), Bash(uv run python *)
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git status), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git checkout *), Bash(git branch *), Bash(git push *), Bash(git pull *), Bash(git fetch *), Bash(git -C *), Bash(git worktree *), Bash(gh pr create *), Bash(gh pr view *), Bash(gh pr list *), Bash(gh pr diff *), Bash(gh pr edit *), Bash(gh api *), Bash(gh issue list *), Bash(gh issue edit *), Bash(gh issue close *), Bash(gh issue comment *), Bash(ls *), Bash(mkdir *), Bash(date *), Bash(uv run python *)
 ---
 
 You are the heartbeat agent. The runner (heartbeat.sh) discovers available issues and PRs, filters out claimed ones, and passes you randomized lists. Your job: work the highest-priority item using the three-tier priority below.
@@ -63,10 +63,13 @@ Work the highest-priority tier:
 - Address each comment: implement fixes, respond to questions, explain decisions.
 - Commit, push. The human will re-review.
 
-**Tier 3: New issues** (lowest priority)
+**Tier 3: New issues** (low priority)
 Only pick up new issues when no PRs need attention. Check for existing open PRs first: `gh pr list --search "issue-NUMBER"` to avoid duplicates.
 
 **Prior art review first.** Before implementing, run the full prior art review (see section 1.6) for this issue. Check all PRs (merged + unmerged) related to it. Merged PRs mean work shipped — understand the approach. Unmerged PRs mean a prior attempt failed — read the diff and comments to learn why.
+
+**Tier 4: Issue curation** (lowest priority)
+When ALL repos have no open issues or PRs needing work, curate existing issues using the `issue_curator` skill. Curation before creation — clean up the backlog before proposing new work. This includes merging duplicates, closing infeasible issues, improving descriptions, and reopening issues that deserve a second look. At most 5 curation actions per session.
 
 ## 1.6 Prior Art Review
 

--- a/skills/issue_curator/SKILL.md
+++ b/skills/issue_curator/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: issue_curator
+description: >
+  Review and curate GitHub issues: merge duplicates, close bad ideas, improve
+  descriptions, and reopen relevant closed issues. Use when maintaining issue
+  quality across a repo, during heartbeat triage, or when issue lists have grown
+  stale. Do NOT use for creating new issues or for implementation work.
+---
+
+Curate a repo's GitHub issues to keep the backlog healthy. Curation before creation — clean up what exists before proposing new work.
+
+## Process
+
+### 1. Gather all issues
+
+Fetch open and closed issues. Use `gh api` to search across states:
+
+```bash
+# All open issues
+gh api "repos/OWNER/REPO/issues?state=open&per_page=100" --jq '[.[] | select(.pull_request == null) | {number, title, body, state, labels: [.labels[].name]}]'
+
+# Recently closed issues (last 90 days)
+gh api "repos/OWNER/REPO/issues?state=closed&since=$(date -u -v-90d +%Y-%m-%dT%H:%M:%SZ)&per_page=100" --jq '[.[] | select(.pull_request == null) | {number, title, body, state, labels: [.labels[].name]}]'
+```
+
+### 2. Identify duplicates
+
+Group issues by theme. Two issues are duplicates if resolving one would resolve the other. When found:
+
+1. Pick the better-specified issue as the survivor
+2. Comment on the duplicate: "Duplicate of #N. Closing in favor of the better-specified issue."
+3. Close the duplicate with `gh issue close`
+4. Comment on the survivor linking the duplicate for context
+
+### 3. Close issues that won't work
+
+An issue should be closed if:
+- Research or prior PR attempts revealed it's infeasible
+- The underlying problem was solved a different way
+- The approach described is fundamentally flawed
+- It depends on blocked prerequisites with no path forward
+
+When closing, comment with a clear explanation of WHY it won't work. Reference specific evidence (PRs, commits, external constraints). Never close without explanation.
+
+### 4. Reopen relevant closed issues
+
+A closed issue should be reopened if:
+- The original reason for closing no longer applies
+- New capabilities or context make it feasible now
+- It was closed as a duplicate but the survivor was also closed without resolution
+
+When reopening, comment explaining what changed and why it's worth revisiting.
+
+### 5. Improve issue descriptions
+
+For issues that survive curation, improve them if:
+- The title is vague (rewrite to be specific and actionable)
+- Acceptance criteria are missing (add them via comment)
+- The body has typos or unclear language (edit via `gh api` PATCH)
+- Dependencies aren't documented (add blocking/blocked-by references)
+
+Do NOT rewrite issues that are already clear. Only touch what needs improvement.
+
+### 6. Report
+
+After curation, summarize what you did:
+- Issues closed as duplicates (with survivor references)
+- Issues closed as infeasible (with reasons)
+- Issues reopened (with justification)
+- Issues improved (with what changed)
+- Remaining open issue count
+
+## Constraints
+
+- **At most 5 actions per session.** Curation is sensitive — don't mass-close.
+- **Always explain closures.** A comment is required before closing.
+- **Preserve intent.** When editing issue descriptions, keep the original author's intent. Add clarity, don't change direction.
+- **No code changes.** Curation is planning, not implementation.


### PR DESCRIPTION
Fixes #171

## Summary
- New prompt-only `issue_curator` skill for curating GitHub issues: merge duplicates, close infeasible issues, improve descriptions, and reopen relevant closed issues
- Added Tier 4 to heartbeat SKILL.md: when ALL repos have no open issues or PRs, curate existing issues before proposing new work (curation before creation)
- Added `Bash(gh issue list *)` to heartbeat SKILL.md allowed-tools (prior art review section already uses `gh issue list` but it was missing from the frontmatter)
- Updated README.md skill inventory and dependency graph

## Follow-up needed
`heartbeat.sh` also needs `Bash(gh issue list *)` added to its `--allowedTools` array. This is a path-restricted file requiring a human-authored change.

## Prior art
- PR #86 (closed): first triage mode attempt, superseded by #161's PR-first workflow
- Issue #160: original tier 4 spec for issue creation
- Issue #168: detailed tier 4 spec (issue creation + heartbeat.sh triage mode)
- Issue #171 proposes curation as the step before creation

## Test plan
- [x] `make lint` passes
- [x] `uv run python -m pytest` passes (304 passed, 27 skipped)
- [ ] Verify issue_curator skill loads correctly in Claude Code
- [ ] Test curation flow on a repo with duplicate/stale issues


Generated with [Claude Code](https://claude.com/claude-code)