### PR TITLE
Add Codex models to discussion_partners (#194)

### DIFF
--- a/skills/discussion_partners/SKILL.md
+++ b/skills/discussion_partners/SKILL.md
@@ -17,6 +17,8 @@ Query another AI model for an outside perspective on a difficult problem. One me
 | Model | When to use | API key needed |
 |-------|-------------|----------------|
 | `openai:gpt-5.2` **(default)** | Primary partner. xhigh thinking, exceptional detail | `OPENAI_API_KEY` |
+| `openai:codex-mini-latest` | Fast code-focused reasoning. Good for implementation questions | `OPENAI_API_KEY` |
+| `openai:gpt-5.1-codex` | Deep code reasoning. Best for architecture and complex debugging | `OPENAI_API_KEY` |
 | `google-gla:gemini-3-1-pro` | Second opinion, brilliantly intelligent reasoning | `GOOGLE_API_KEY` |
 | `anthropic:claude-opus-4-6` | Third perspective, different reasoning style | `ANTHROPIC_API_KEY` |
 
@@ -58,16 +60,16 @@ uv run --directory SKILL_DIR python scripts/ask_model.py -m anthropic:claude-opu
 # Gemini 3 Pro with thinking enabled
 uv run --directory SKILL_DIR python scripts/ask_model.py -m google-gla:gemini-3-pro-preview "question"
 
-# Codex models (via OpenAI Responses API)
-uv run --directory SKILL_DIR python scripts/ask_model.py -m openai-responses:gpt-5-codex "question"
-uv run --directory SKILL_DIR python scripts/ask_model.py -m openai-responses:codex-mini-latest "question"
+# Codex models (code-focused reasoning)
+uv run --directory SKILL_DIR python scripts/ask_model.py -m openai:codex-mini-latest "question"
+uv run --directory SKILL_DIR python scripts/ask_model.py -m openai:gpt-5.1-codex "question"
 ```
 
 ## API Key Setup
 
 Add keys to your shell profile (`~/.zshrc` or `~/.bashrc`):
 ```bash
-export OPENAI_API_KEY="your-key"      # Required for openai: and openai-responses: models
+export OPENAI_API_KEY="your-key"      # Required for openai: models (including Codex)
 export ANTHROPIC_API_KEY="your-key"   # Required for anthropic: models
 export GOOGLE_API_KEY="your-key"      # Required for google-gla: models
 ```
@@ -82,7 +84,7 @@ variable to set. If the key exists but the call fails, common errors:
 
 - `--model` / `-m`: Full pydantic-ai model string (default: `openai:gpt-5.2`)
 - `--system` / `-s`: Optional system prompt override
-- `--list-models` / `-l`: List known model names, optionally filtered by prefix (e.g. `-l openai`, `-l anthropic`). Codex models appear under `openai:` but must be called with `openai-responses:` prefix.
+- `--list-models` / `-l`: List known model names, optionally filtered by prefix (e.g. `-l openai`, `-l anthropic`).
 
 ## Multiple Calls
 

--- a/skills/discussion_partners/scripts/ask_model.py
+++ b/skills/discussion_partners/scripts/ask_model.py
@@ -20,10 +20,6 @@ PROVIDER_CONFIG: dict[str, tuple[str, dict[str, Any]]] = {
         "OPENAI_API_KEY",
         {"openai_reasoning_effort": "xhigh"},
     ),
-    "openai-responses": (
-        "OPENAI_API_KEY",
-        {"openai_reasoning_effort": "xhigh"},
-    ),
     "anthropic": (
         "ANTHROPIC_API_KEY",
         {"anthropic_thinking": {"type": "adaptive"}, "anthropic_effort": "max"},

--- a/tests/unit/test_ask_model.py
+++ b/tests/unit/test_ask_model.py
@@ -34,10 +34,11 @@ class TestParseProvider:
         assert prefix == "openai"
         assert "openai_reasoning_effort" in thinking
 
-    def test_openai_responses_prefix(self) -> None:
-        key_name, prefix, thinking = ask_model._parse_provider("openai-responses:gpt-5.2")
+    def test_codex_model_uses_openai_prefix(self) -> None:
+        key_name, prefix, thinking = ask_model._parse_provider("openai:codex-mini-latest")
         assert key_name == "OPENAI_API_KEY"
-        assert prefix == "openai-responses"
+        assert prefix == "openai"
+        assert thinking["openai_reasoning_effort"] == "high"  # mini → capped
 
     def test_anthropic_prefix(self) -> None:
         key_name, prefix, thinking = ask_model._parse_provider("anthropic:claude-opus-4-6")


### PR DESCRIPTION
Fixes #194

## Summary

- Added `openai:codex-mini-latest` and `openai:gpt-5.1-codex` to the Recommended Models table with usage guidance
- Updated Codex examples in the Models section to use the `openai:` prefix (pydantic-ai's KnownModelName) instead of the undocumented `openai-responses:` prefix
- Removed the `openai-responses` entry from PROVIDER_CONFIG since Codex models are first-class under the `openai:` prefix in current pydantic-ai
- Updated test to verify Codex model parsing (including reasoning effort capping for codex-mini)

## Test plan

- [x] All 311 tests pass, 0 failures
- [x] Ruff lint passes
- [x] Pre-commit hooks pass