### PR TITLE
Add mobile_bridge skill via Slack MCP (#65)

### DIFF
--- a/skills/mobile_bridge/SKILL.md
+++ b/skills/mobile_bridge/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: mobile_bridge
+description: >
+  Phone-to-Claude capture via Slack MCP. Use when the user wants to check
+  their Slack inbox channel for messages to capture, or when the heartbeat
+  should periodically process incoming messages from Slack.
+  Do NOT use for general Slack operations (use the Slack MCP tools directly)
+  or for sending messages TO the user (use ntfy or direct Slack MCP).
+---
+
+Reads messages from a designated Slack channel and routes each one through the `capture` skill.
+
+## Prerequisites
+
+One-time setup — the user must configure the Slack MCP server:
+
+```bash
+claude mcp add --transport http --scope user slack https://mcp.slack.com/mcp
+```
+
+This triggers an OAuth flow — authorize your Slack workspace when prompted. No API keys, no bot tokens, no admin approval needed.
+
+Then create a `#claude-inbox` channel in your Slack workspace (or any channel — configure the name below).
+
+## Configuration
+
+The inbox channel name defaults to `#claude-inbox`. The user can override this by setting a different channel name in their Agent Goals or by telling the agent directly.
+
+## Processing Workflow
+
+When invoked (manually or by heartbeat):
+
+1. **List recent messages** in the inbox channel using the Slack MCP `slack_list_channel_messages` tool (or equivalent — tool names vary by MCP server version). Look for unprocessed messages since the last check.
+
+2. **For each message**, route through the `capture` skill:
+   - The message text is the input
+   - Let capture classify (ephemeral/durable/task/guidance) and route to the right destination
+   - If the message contains a URL, also consider the `web_grab` skill
+
+3. **Acknowledge** each processed message by replying in the Slack thread: "Captured → [destination]" so the user knows it was processed.
+
+4. **Log** what was processed to `hierarchical_memory` as a daily note entry:
+   ```
+   Mobile bridge: processed N messages from #claude-inbox
+   - "message summary" → destination
+   ```
+
+## Heartbeat Integration
+
+When invoked from the heartbeat, check `#claude-inbox` for any messages posted since the last heartbeat cycle. Process each one. If the channel is empty or has no new messages, skip silently — do not log "no messages."
+
+## Failure Modes
+
+- **MCP not configured**: If Slack MCP tools are not available, tell the user to run the setup command above.
+- **Channel not found**: If the inbox channel doesn't exist, tell the user to create it.
+- **OAuth expired**: If MCP calls fail with auth errors, tell the user to re-authorize: `claude mcp add --transport http --scope user slack https://mcp.slack.com/mcp`


### PR DESCRIPTION
Fixes #65

## Summary

Replaces the rejected Python CLI approach (PR #121) with a radically simpler prompt-only skill that uses Slack's official MCP server.

**Prior art:** PR #121 was closed — zachmayer said "too complex, replace with a slack mcp or connector." This PR does exactly that.

**What changed:** +56 lines, single file, no Python code. The entire skill is a SKILL.md that tells the agent how to use the Slack MCP server for phone-to-Claude capture.

## How It Works

1. **One-time setup:** `claude mcp add --transport http --scope user slack https://mcp.slack.com/mcp` (triggers OAuth, no API keys needed)
2. **User workflow:** Send message to `#claude-inbox` from Slack mobile app
3. **Agent workflow:** Read channel via MCP tools, route each message through the `capture` skill, acknowledge in thread
4. **Heartbeat integration:** Periodically checks the inbox channel for new messages

## Design Decisions

- **Official Slack MCP server** (`https://mcp.slack.com/mcp`) over the deprecated Anthropic reference implementation or community servers — OAuth-based, no bot token management, maintained by Slack
- **Prompt-only** — no Python scripts, no dependencies, no test suite needed. The MCP server provides the tools; the skill provides the workflow
- **Delegates to capture skill** — doesn't reinvent routing logic, just feeds messages into the existing capture pipeline
- **56 lines** vs PR #121's 200+ lines of Python + tests

## Test plan

- [x] 217 skill validation tests pass, 28 skipped
- [x] Lint clean
- [x] SKILL.md under 500 lines (56 lines)
- [x] Frontmatter valid with name + description
- [x] WHEN/WHEN NOT pattern in description