### PR TITLE
Add codex to discussion_partners

### DIFF
--- a/skills/discussion_partners/SKILL.md
+++ b/skills/discussion_partners/SKILL.md
@@ -19,6 +19,8 @@ Query another AI model for an outside perspective on a difficult problem. One me
 | `openai:gpt-5.2` **(default)** | Primary partner. xhigh thinking, exceptional detail | `OPENAI_API_KEY` |
 | `google-gla:gemini-3.1-pro-preview` | Second opinion, brilliantly intelligent reasoning | `GOOGLE_API_KEY` |
 | `anthropic:claude-opus-4-6` | Third perspective, different reasoning style | `ANTHROPIC_API_KEY` |
+| `openai-responses:codex-mini-latest` | Fast coding partner; coding-focused reasoning | `OPENAI_API_KEY` |
+| `openai-responses:gpt-5-codex` | Deep coding analysis via Responses API | `OPENAI_API_KEY` |
 
 Before calling, verify the required API key is set: `echo $OPENAI_API_KEY | head -c 8` (should show `sk-...`).
 
@@ -39,7 +41,7 @@ Good: "Here is my auth middleware [code]. Users with expired tokens get a 500 in
 ## Usage
 
 ```bash
-uv run --directory SKILL_DIR python scripts/ask_model.py -m <model> "Your detailed question with full context"
+uv run --script SKILL_DIR/scripts/ask_model.py -m <model> "Your detailed question with full context"
 ```
 
 Where `SKILL_DIR` is the directory containing this skill. The `-m` flag takes a full [pydantic-ai model string](https://ai.pydantic.dev/api/models/) — the provider prefix determines which API key and thinking settings to use.
@@ -50,17 +52,17 @@ The default is `openai:gpt-5.2`. Thinking effort is automatically set to maximum
 
 ```bash
 # GPT-5.2 with xhigh reasoning (default — just omit -m)
-uv run --directory SKILL_DIR python scripts/ask_model.py "question"
+uv run --script SKILL_DIR/scripts/ask_model.py "question"
 
 # Claude Opus 4.6 with adaptive thinking at max effort
-uv run --directory SKILL_DIR python scripts/ask_model.py -m anthropic:claude-opus-4-6 "question"
+uv run --script SKILL_DIR/scripts/ask_model.py -m anthropic:claude-opus-4-6 "question"
 
 # Gemini 3.1 Pro with thinking enabled
-uv run --directory SKILL_DIR python scripts/ask_model.py -m google-gla:gemini-3.1-pro-preview "question"
+uv run --script SKILL_DIR/scripts/ask_model.py -m google-gla:gemini-3.1-pro-preview "question"
 
 # Codex models (via OpenAI Responses API)
-uv run --directory SKILL_DIR python scripts/ask_model.py -m openai-responses:gpt-5-codex "question"
-uv run --directory SKILL_DIR python scripts/ask_model.py -m openai-responses:codex-mini-latest "question"
+uv run --script SKILL_DIR/scripts/ask_model.py -m openai-responses:codex-mini-latest "question"
+uv run --script SKILL_DIR/scripts/ask_model.py -m openai-responses:gpt-5-codex "question"
 ```
 
 ## API Key Setup

--- a/skills/discussion_partners/scripts/ask_model.py
+++ b/skills/discussion_partners/scripts/ask_model.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "click>=8.3.0",
+#     "pydantic-ai[openai,anthropic,google]>=1.62.0",
+# ]
+# ///
 """Ask a question to another AI model using pydantic-ai with thinking enabled."""
 
 import os


### PR DESCRIPTION
## Summary

- Add PEP 723 inline script metadata to ask_model.py with pydantic-ai[openai,anthropic,google] and click deps
- Switch all invocations to uv run --script so the isolated inline env is used
- Add openai-responses:codex-mini-latest and openai-responses:gpt-5-codex to the Recommended Models table

Closes #194

## Test plan
- [ ] uv run --script skills/discussion_partners/scripts/ask_model.py --help works with no project venv needed
- [ ] Codex invocation example in SKILL.md runs correctly with a valid OPENAI_API_KEY

Generated with Claude Code