### PR TITLE
Add Codex to discussion_partners

### DIFF
--- a/skills/discussion_partners/SKILL.md
+++ b/skills/discussion_partners/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: discussion_partners
 description: >
-  Ask a question to another AI model (OpenAI, Anthropic, or Google) with
-  extended thinking enabled. Use when you are stuck on a difficult problem,
-  suspect you are spinning your wheels, or sense there is an angle you have
-  not considered. Do NOT use for routine tasks you can handle directly.
+  Ask a question to another AI model (OpenAI, Anthropic, Google, or Codex)
+  with extended thinking enabled. Use when you are stuck on a difficult
+  problem, suspect you are spinning your wheels, or sense there is an angle
+  you have not considered. Do NOT use for routine tasks you can handle
+  directly.
 allowed-tools: Bash(uv run *)
 ---
 
@@ -19,6 +20,7 @@ Query another AI model for an outside perspective on a difficult problem. One me
 | `openai:gpt-5.2` **(default)** | Primary partner. xhigh thinking, exceptional detail | `OPENAI_API_KEY` |
 | `google-gla:gemini-3.1-pro-preview` | Second opinion, brilliantly intelligent reasoning | `GOOGLE_API_KEY` |
 | `anthropic:claude-opus-4-6` | Third perspective, different reasoning style | `ANTHROPIC_API_KEY` |
+| `openai-responses:codex-mini-latest` | Coding specialist — code review, debugging, refactors | `OPENAI_API_KEY` |
 
 Before calling, verify the required API key is set: `echo $OPENAI_API_KEY | head -c 8` (should show `sk-...`).
 
@@ -38,11 +40,27 @@ Good: "Here is my auth middleware [code]. Users with expired tokens get a 500 in
 
 ## Usage
 
+For short, single-line questions, pass directly as an argument:
+
 ```bash
-uv run --directory SKILL_DIR python scripts/ask_model.py -m <model> "Your detailed question with full context"
+uv run --directory SKILL_DIR python scripts/ask_model.py "Why would a bash trap handler not fire on SIGTERM?"
 ```
 
-Where `SKILL_DIR` is the directory containing this skill. The `-m` flag takes a full [pydantic-ai model string](https://ai.pydantic.dev/api/models/) — the provider prefix determines which API key and thinking settings to use.
+For longer questions — code review diffs, multi-file context, anything with newlines or special characters — write to a file first and use `--input-file`:
+
+```bash
+# Write your question/context to a file
+# Then pass via --input-file (-f) to avoid shell quoting issues
+uv run --directory SKILL_DIR python scripts/ask_model.py -m <model> -f /tmp/my-question.txt
+```
+
+The script also supports standalone execution via `uv run --script` (no project install needed — deps declared inline):
+
+```bash
+uv run --script SKILL_DIR/scripts/ask_model.py "question"
+```
+
+`SKILL_DIR` is the directory containing this skill. The `-m` flag takes a full [pydantic-ai model string](https://ai.pydantic.dev/api/models/) — the provider prefix determines which API key and thinking settings to use.
 
 ## Models
 
@@ -82,6 +100,7 @@ variable to set. If the key exists but the call fails, common errors:
 
 - `--model` / `-m`: Full pydantic-ai model string (default: `openai:gpt-5.2`)
 - `--system` / `-s`: Optional system prompt override
+- `--input-file` / `-f`: Read question from a file instead of CLI argument. Use for large payloads (code review diffs, long analyses) to avoid shell quoting issues.
 - `--list-models` / `-l`: List known model names, optionally filtered by prefix (e.g. `-l openai`, `-l anthropic`). Codex models appear under `openai:` but must be called with `openai-responses:` prefix.
 
 ## Multiple Calls

--- a/skills/discussion_partners/scripts/ask_model.py
+++ b/skills/discussion_partners/scripts/ask_model.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "click>=8.3.0",
+#   "pydantic-ai-slim[openai,anthropic,google]>=1.63.0",
+# ]
+# ///
 """Ask a question to another AI model using pydantic-ai with thinking enabled."""
 
 import os
@@ -96,11 +103,19 @@ def _handle_api_error(e: Exception, prefix: str, key_name: str) -> None:
 @click.option(
     "--list-models", "-l", default=None, help="List known models (optionally filter by prefix)"
 )
+@click.option(
+    "--input-file",
+    "-f",
+    type=click.Path(exists=True),
+    default=None,
+    help="Read question from a file instead of CLI argument",
+)
 @click.argument("question", required=False)
 def main(
     model: str,
     system: str | None,
     list_models: str | None,
+    input_file: str | None,
     question: str | None,
 ) -> None:
     """Ask a question to another AI model with extended thinking."""
@@ -111,8 +126,13 @@ def main(
                 click.echo(name)
         return
 
+    if input_file:
+        with open(input_file) as fh:
+            question = fh.read().strip()
     if not question:
-        raise click.UsageError("Missing argument 'QUESTION'.")
+        raise click.UsageError(
+            "Missing argument 'QUESTION'. Provide as argument or via --input-file."
+        )
 
     key_name, prefix, thinking = _parse_provider(model)
 


### PR DESCRIPTION
## Summary

- Add PEP 723 inline script metadata to ask_model.py so it works standalone via uv run --script (deps: pydantic-ai-slim with openai,anthropic,google extras >=1.63.0)
- Add codex-mini-latest to recommended models table in SKILL.md
- Update skill description to mention Codex alongside OpenAI, Anthropic, Google
- Add --input-file/-f option for large payloads (diffs, multi-file context)
- Expand usage section with short/long/standalone examples

Closes #194

## Test plan

- [ ] uv run --script scripts/ask_model.py -l openai — confirm no warnings and codex models listed
- [ ] uv run --script scripts/ask_model.py -m openai-responses:codex-mini-latest "What is 2+2?" — confirm Codex responds
- [ ] make lint passes
- [ ] make test passes
