### PR TITLE
Add Codex to discussion_partners

### DIFF
--- a/skills/discussion_partners/SKILL.md
+++ b/skills/discussion_partners/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: discussion_partners
 description: >
-  Ask a question to another AI model (OpenAI, Anthropic, or Google) with
-  extended thinking enabled. Use when you are stuck on a difficult problem,
-  suspect you are spinning your wheels, or sense there is an angle you have
-  not considered. Do NOT use for routine tasks you can handle directly.
+  Ask a question to another AI model (OpenAI, Anthropic, Google, or Codex)
+  with extended thinking enabled. Use when you are stuck on a difficult
+  problem, suspect you are spinning your wheels, or sense there is an angle
+  you have not considered. Do NOT use for routine tasks you can handle
+  directly.
 allowed-tools: Bash(uv run *)
 ---
 

--- a/skills/discussion_partners/scripts/ask_model.py
+++ b/skills/discussion_partners/scripts/ask_model.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "click>=8.3.0",
+#   "pydantic-ai-slim[openai,anthropic,google]>=1.63.0",
+# ]
+# ///
 """Ask a question to another AI model using pydantic-ai with thinking enabled."""
 
 import os
@@ -96,11 +103,19 @@ def _handle_api_error(e: Exception, prefix: str, key_name: str) -> None:
 @click.option(
     "--list-models", "-l", default=None, help="List known models (optionally filter by prefix)"
 )
+@click.option(
+    "--input-file",
+    "-f",
+    type=click.Path(exists=True),
+    default=None,
+    help="Read question from a file instead of CLI argument",
+)
 @click.argument("question", required=False)
 def main(
     model: str,
     system: str | None,
     list_models: str | None,
+    input_file: str | None,
     question: str | None,
 ) -> None:
     """Ask a question to another AI model with extended thinking."""
@@ -111,8 +126,13 @@ def main(
                 click.echo(name)
         return
 
+    if input_file:
+        with open(input_file) as fh:
+            question = fh.read().strip()
     if not question:
-        raise click.UsageError("Missing argument 'QUESTION'.")
+        raise click.UsageError(
+            "Missing argument 'QUESTION'. Provide as argument or via --input-file."
+        )
 
     key_name, prefix, thinking = _parse_provider(model)
 


### PR DESCRIPTION
## Summary
- Add PEP 723 inline script metadata so uv run --script works without project install
- Add codex-mini-latest to recommended models table (openai-responses: prefix required)
- Update SKILL.md description frontmatter to mention Codex
- Add --input-file/-f option for large payloads
- Expand Usage section with examples and standalone execution docs

## Test plan
- [x] 322 tests pass, 30 skipped
- [x] Lint clean
- [x] uv run --script installs inline deps without warnings
- [x] Provider parsing routes openai-responses:codex-mini-latest correctly

Supersedes #240 and #202 (atomic PR with only discussion_partners changes).

Closes #194
