### PR TITLE
Allow Read/Edit/Write to /tmp in settings template

### DIFF
--- a/settings.template.json
+++ b/settings.template.json
@@ -76,6 +76,9 @@
       "Bash(uv tool run*)",
       "Bash(uv cache clean*)",
       "Bash(uvx *)",
+      "Read(/tmp/**)",
+      "Edit(/tmp/**)",
+      "Write(/tmp/**)",
       "Edit(~/claude/obsidian/**)",
       "Write(~/claude/obsidian/**)"
     ],


### PR DESCRIPTION
## Summary
- Adds `Read(/tmp/**)`, `Edit(/tmp/**)`, `Write(/tmp/**)` to the allow list in `settings.template.json`
- Heartbeat agents need /tmp access for worktree isolation (tempfile.mkdtemp) and temporary file operations

## Test plan
- [ ] Verify `make install` copies the updated template correctly
- [ ] Confirm heartbeat agents can create and write to /tmp paths without permission prompts

Generated with [Claude Code](https://claude.com/claude-code)
