### PR TITLE
Fix updater workflow: use GITHUB_TOKEN instead of missing secret

### DIFF
--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
   - cron:  '0 10 * * 1'  # every monday at 10 AM
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-dep:
     runs-on: ubuntu-latest
@@ -38,7 +42,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:
-        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Update dependencies
         title: Update dependencies
         branch: update-dependencies


### PR DESCRIPTION
Closes #269

## Summary
The Update Dependencies workflow (`.github/workflows/updater.yaml`) failed because it referenced `secrets.PERSONAL_ACCESS_TOKEN`, which doesn't exist in the repo. Switched to `secrets.GITHUB_TOKEN` and added the required `permissions` block (`contents: write`, `pull-requests: write`).

**Note**: GPT-5.2 flagged that PRs created with `GITHUB_TOKEN` won't trigger downstream CI workflows (a GitHub security limitation to prevent loops). If you need CI to run on these auto-created dependency PRs, you'd need to configure a PAT instead. The current fix gets the workflow running without requiring new secrets.

## Review
- GPT-5.2: Conditional approve — flags GITHUB_TOKEN CI limitation, suggests PAT if downstream CI needed
- Claude Sonnet 4.6: Approve

## Test plan
- [x] `make test` passes (322 passed, 30 skipped)
- [x] `make lint` passes
- [ ] Verify via `workflow_dispatch` trigger after merge
