### PR TITLE
Add .beads/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ cython_debug/
 .runtime/
 .claude/
 .logs/
+.beads/


### PR DESCRIPTION
## Summary
- Add .beads/ directory to .gitignore (Gas Town runtime dir)

## Source
Merge request sk-wisp-mkpb, source issue sk-cza (polecat/quartz)