### PR TITLE
Coding agent: use prior_art_review skill on fresh issues

### DIFF
--- a/skills/heartbeat/agents/coding.md
+++ b/skills/heartbeat/agents/coding.md
@@ -39,7 +39,9 @@ $BRANCH_STATUS
 Before doing anything, determine where this PR stands:
 
 **Fresh issue, no code**: Branch has no meaningful changes vs main.
-The queue agent already scoped this issue — start coding.
+The queue agent already scoped this issue. Load the `prior_art_review`
+skill and review related PRs listed above — read their diffs and comments
+to learn what was tried and why it failed. Then start coding.
 
 **Code exists, needs changes**: Feedback or CI failures indicate
 specific fixes needed. Address the feedback.


### PR DESCRIPTION
## Summary

On fresh issues (no existing code), the coding agent now loads the `prior_art_review` skill to read diffs and comments from related PRs before writing code. This prevents repeating mistakes from failed prior attempts.

The orchestrator already passes `$RELATED_PRS` with PR numbers, but the agent wasn't reading the actual diffs/comments. Now it does.

## Test plan

- [x] `make test` — 32 orchestrator tests pass
- [ ] Manual: verify on next heartbeat cycle that the agent loads the skill
