### PR TITLE
Add Hoare's Dictum mental model

### DIFF
--- a/.claude/skills/mental_models/SKILL.md
+++ b/.claude/skills/mental_models/SKILL.md
@@ -126,6 +126,8 @@ These require recognition, not protocol. Knowing the name is usually enough to c
 
 **Scout Mindset** (Julia Galef) — Your goal is to see what's actually there, not to build a case for what you want to see. Treat being wrong as an update, not a failure. The measure of good reasoning is calibration, not confidence. See [scout-mindset.md](scout-mindset.md).
 
+**Hoare's Dictum** — Two ways to build software: so simple there are obviously no deficiencies, or so complicated there are no obvious deficiencies. The first is far harder — and far better. Prefer designs you can prove correct by inspection over designs too complex to find bugs in. See [hoares-dictum.md](hoares-dictum.md).
+
 ## Application
 
 Almost every non-trivial problem benefits from at least one mental model. When you encounter a decision, analysis, or debugging task, scan this index for a fit — there is usually one. Multiple models often apply simultaneously; use whichever combination illuminates the situation.

--- a/.claude/skills/mental_models/hoares-dictum.md
+++ b/.claude/skills/mental_models/hoares-dictum.md
@@ -1,0 +1,23 @@
+# Hoare's Dictum
+
+> There are two ways of constructing software: one way is to make it so simple that there are obviously no deficiencies, and the other way is to make it so complicated that there are no obvious deficiencies. The first method is far more difficult. — C. A. R. Hoare
+
+## Core Idea
+
+Simplicity with obvious correctness beats complexity with hidden deficiencies. The hard part isn't making something complex — it's making something simple enough that you can see it's right.
+
+Complements Occam's Razor (simplest *explanation*) — Hoare's Dictum is about simplest *construction*. Occam's asks "which theory fits?" Hoare's asks "can you prove this design correct by inspection?"
+
+## Application
+
+- **Architecture:** If you can't explain the system in one paragraph, it's too complicated to verify. Prefer designs where correctness is obvious over designs where bugs are merely non-obvious.
+- **API design:** A good API has few methods with clear contracts. If users need a tutorial to avoid misuse, the API is wrong.
+- **Code review:** "I can't find any bugs" is weaker than "I can see this is correct." Aim for the second.
+- **Testing:** If you need elaborate test harnesses to verify behavior, the code under test may be too complex. Simple code needs simple tests.
+- **Refactoring:** The goal isn't fewer lines — it's fewer concepts. Reduce the number of things a reader must hold in their head simultaneously.
+
+## Common Misuse
+
+- **Conflating simple with easy.** Simple designs are often harder to achieve than complex ones. "Just make it simpler" is not actionable advice — it requires deep understanding of the problem.
+- **Using it to reject all complexity.** Some problems are inherently complex. The dictum says prefer simplicity where possible, not that complexity is always wrong. Distributed consensus, for example, has irreducible complexity.
+- **Premature simplification.** Oversimplifying before understanding the problem creates designs that are simple but wrong. You must first understand the full problem space, then find the simple design within it.


### PR DESCRIPTION
Closes #286

## Summary
Adds Hoare's Dictum as a new mental model under Design & Communication. The principle — simplicity with obvious correctness beats complexity with hidden deficiencies — complements Occam's Razor (which covers explanations) by focusing on construction and design.

## Sources
- C.A.R. Hoare, 1980 ACM Turing Award Lecture
- https://news.ycombinator.com/item?id=47248683

## Review
- GPT-5.4: Minor style suggestions (soften absolute phrasing), otherwise approve
- Gemini 3.1 Pro: Approve (checked alphabetical ordering — section is not alphabetically sorted, placement is consistent)
- Claude Opus 4.6: API error, not available

## Test plan
- [x] make test passes (384 passed)
- [x] make lint passes
