### PR TITLE
Fix heartbeat: strip CLAUDECODE env var for child agents

### DIFF
--- a/.claude/skills/heartbeat/scripts/orchestrator.py
+++ b/.claude/skills/heartbeat/scripts/orchestrator.py
@@ -430,10 +430,13 @@ def invoke_agent(agent_name, workdir, context, issue_number, repo, *, budget=8):
         "-p",
         context,
     ]
+    # Strip CLAUDECODE env var so child agents don't think they're nested
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
     # Append so queue→coding→review logs accumulate in one file
     with open(lf, "a") as f:
         f.write(f"\n{'=' * 60}\n[{agent_name}] agent invocation\n{'=' * 60}\n")
-        result = subprocess.run(cmd, cwd=workdir, stdout=f, stderr=subprocess.STDOUT)
+        result = subprocess.run(cmd, cwd=workdir, stdout=f, stderr=subprocess.STDOUT, env=env)
         f.write(f"\n[{agent_name}] exit code: {result.returncode}\n")
     return result.returncode
 


### PR DESCRIPTION
When the orchestrator runs inside a Claude Code session (manual kick), child agents fail with:

> Error: Claude Code cannot be launched inside another Claude Code session.

All 3 active PRs (#295, #296, #297) hit this when I tried to run the orchestrator manually.

Fix: strip the `CLAUDECODE` env var from the subprocess environment so child agents don't detect a parent session.

Also found: the launchd plist still points to the old `skills/heartbeat/` path (pre-#298 move). Run `make install-heartbeat` after merging to fix the plist.
