### PR TITLE
Fix heartbeat has_diff: check file changes not commit count

### DIFF
--- a/.claude/skills/heartbeat/scripts/orchestrator.py
+++ b/.claude/skills/heartbeat/scripts/orchestrator.py
@@ -355,8 +355,9 @@ def is_behind_main(workdir):
 
 
 def has_diff(workdir):
-    """Check if the branch has commits beyond origin/main."""
-    return _rev_list_count(workdir, "origin/main..HEAD") > 0
+    """Check if the branch has actual file changes vs origin/main."""
+    result = run(["git", "diff", "--stat", "origin/main..HEAD"], cwd=workdir, capture=True)
+    return bool(result.stdout.strip())
 
 
 def run_verification(workdir):


### PR DESCRIPTION
Fix `has_diff()` to check for actual file changes (via `git diff --stat`) instead of just counting commits beyond main.

The old check (`rev-list count`) returned true for branches with empty "begin work" commits (0 additions, 0 deletions), causing the orchestrator to promote empty PRs (#296) to review.
