### PR TITLE
Add Google Workspace CLI skill and make auth target

### DIFF
--- a/.claude/skills/gws_cli/SKILL.md
+++ b/.claude/skills/gws_cli/SKILL.md
@@ -119,7 +119,7 @@ Supports multiple Google accounts (home, work, school, etc.) via `~/.claude/gws-
 
 **Rules:**
 - Bare `gws ...` uses the default account. No env var needed.
-- For non-default accounts, use the wrapper script: `.claude/skills/gws_cli/scripts/gws-as.sh <profile> <gws args...>`
+- For non-default accounts, use the wrapper script: `~/.claude/skills/gws_cli/scripts/gws-as.sh <profile> <gws args...>`
 - If the user names an account, email, or domain, use the matching profile.
 - If ambiguous and the action is a write/send/delete, ask which account.
 - If `gws-accounts.json` is missing, assume only the default account exists.
@@ -129,7 +129,7 @@ Supports multiple Google accounts (home, work, school, etc.) via `~/.claude/gws-
 gws gmail +triage
 
 # Non-default account
-.claude/skills/gws_cli/scripts/gws-as.sh work gmail +triage
+~/.claude/skills/gws_cli/scripts/gws-as.sh work gmail +triage
 ```
 
 ## Auth
@@ -167,7 +167,7 @@ Then add the profile to `~/.claude/gws-accounts.json`. Each entry needs `path` (
 }
 ```
 
-The `default` entry is the account used by bare `gws` commands. All other entries require `gws-as.sh <name>` to use.
+The `default` entry is the account used by bare `gws` commands. All other entries require `~/.claude/skills/gws_cli/scripts/gws-as.sh <name>` to use.
 
 ## Tips
 

--- a/.claude/skills/gws_cli/scripts/gws-as.sh
+++ b/.claude/skills/gws_cli/scripts/gws-as.sh
@@ -20,6 +20,10 @@ if [ $# -lt 1 ]; then
 fi
 
 profile="$1"
+if ! echo "$profile" | grep -Eq '^[a-zA-Z0-9_-]+$'; then
+    echo "ERROR: Invalid profile name '$profile'. Use only letters, numbers, hyphens, underscores." >&2
+    exit 1
+fi
 shift
 
 # Resolve config dir from accounts.json, or fall back to convention

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install: ## Install everything: system deps, UV deps, skills, agents, config
 	@command -v brew >/dev/null || { echo "ERROR: Homebrew required. Install from https://brew.sh"; exit 1; }
 	brew update
 	brew upgrade
-	brew install uv gh pyright node google-cloud-sdk
+	brew install uv gh pyright node jq google-cloud-sdk
 	brew doctor || true
 	npm install -g @googleworkspace/cli
 	@# ── Python + UV dependencies ──

--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ npx skills add zachmayer/skills -g
 ```bash
 git clone https://github.com/zachmayer/skills.git
 cd skills
-gws auth setup          # One-time: create GCP project + OAuth client (requires gcloud)
 make install            # Everything: system deps, UV deps, skills, agents, config, auth
+gws auth setup          # One-time: create GCP project + OAuth client (installed by make install)
+make auth               # Complete Google Workspace login after setup
 make install-heartbeat  # Heartbeat launchd daemon (opt-in, machine-specific)
 ```
 
@@ -195,7 +196,7 @@ Requires [uv](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```bash
 make help           # Show all available targets
-make install        # Install system deps + UV deps + skills + agents + config
+make install        # Install system deps + UV deps + skills + agents + config + auth
 make ci             # CI checks: lint + typecheck + unit tests
 make test           # All checks: CI + integration tests
 make upgrade        # Upgrade all dependencies
@@ -293,6 +294,10 @@ Tracked in [GitHub Issues](https://github.com/zachmayer/skills/issues). Label `a
 - **Playwright browser automation** — Headless browser for JS-heavy pages in web_grab.
 - **Fix install-ci** — Heavy deps isolated: marker-pdf uses PEP 723 inline script metadata (`uv run --script`), playwright is an optional extra.
 - **Settings precedence** — Removed `gh pr create*` from project deny list (PR #43).
+
+### Known trade-offs
+
+- **`make install` runs `brew update/upgrade`** — This upgrades all Homebrew packages, not just ours. It's intentionally aggressive as a stopgap until a dedicated system maintenance solution (launchd job or similar) is set up. Long-term, brew maintenance should be separated from skill installation.
 
 ### Lessons Learned
 


### PR DESCRIPTION
## Summary
- Add gws_cli skill for Google Workspace APIs (Drive, Gmail, Sheets, Calendar) via the gws CLI
- Add make auth target that logs into GitHub (gh) and Google Workspace (gws)
- Install gws via npm in make install (adds node as brew dep)
- Skill incorporates helper commands (+send, +triage, +reply, +watch) and safety rules from the official googleworkspace/cli skill collection, compressed into our single-skill format

## What changed
- **Makefile**: brew install node, npm install -g @googleworkspace/cli, new auth target, updated install message
- **.claude/skills/gws_cli/SKILL.md**: New skill -- helper commands, raw API examples, flags table, schema introspection, safety rules
- **README.md**: Added gws_cli to skill inventory, standalone list, and dev targets

## Test plan
- [ ] make install succeeds (installs node + gws)
- [ ] gws --version works after install
- [ ] make auth prompts for gh and gws login
- [ ] make ci passes

Closes #275
