### PR TITLE
Add build-web target to package skills for Claude.ai

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ SKILLS_WEB_EXCLUDE := \
 
 BUILD_WEB := build/claude-ai
 
-build-web: ## Package web-compatible skills for Claude.ai upload
+build-web: ## Package web-compatible skills as .zip files for Claude.ai upload
 	@rm -rf $(BUILD_WEB)
 	@mkdir -p $(BUILD_WEB)
 	@set -e; for skill_dir in $(SKILLS_DIR)/*/; do \
@@ -181,14 +181,14 @@ build-web: ## Package web-compatible skills for Claude.ai upload
 		done; \
 		if [ "$$skip" = "false" ]; then \
 			echo "  Packaging $$skill_name"; \
-			rsync -a --exclude='__pycache__' --exclude='*.pyc' --exclude='.DS_Store' "$$skill_dir" "$(BUILD_WEB)/$$skill_name/"; \
+			(cd "$$skill_dir" && zip -qr - . -x '__pycache__/*' '*.pyc' '.DS_Store') > "$(BUILD_WEB)/$$skill_name.zip"; \
 		fi; \
 	done
 	@echo ""
 	@included=$$(ls -1 $(BUILD_WEB) | wc -l | tr -d ' '); \
 	total=$$(ls -1d $(SKILLS_DIR)/*/ | wc -l | tr -d ' '); \
 	echo "Packaged $$included/$$total skills → $(BUILD_WEB)/"
-	@echo "Upload each folder to a Claude.ai Project as knowledge files."
+	@echo "Drag .zip files into a Claude.ai Project to install."
 .PHONY: build-web
 
 # ── Heartbeat (opt-in, machine-specific) ─────────────────────────


### PR DESCRIPTION
  ## Summary

  - Adds `make build-web` target that packages web-compatible skills as `.zip` files for Claude.ai upload
  - Blacklist-based: `SKILLS_WEB_EXCLUDE` lists 24 skills requiring auth (API keys, CLI login, or vault git push)
  - Zips the remaining 17 skills into `build/claude-ai/<skill-name>.zip` with `SKILL.md` at the root
  - `build/` already gitignored; target is idempotent (clean rebuild each run)

  ## Usage

  make build-web
  Drag .zip files from build/claude-ai/ into a Claude.ai Project


  ## Design decisions

  - **Blacklist over whitelist**: new skills are included by default (correct default — most new skills should work on the web)
  - **`.zip` output**: Claude.ai accepts `.zip` files containing `SKILL.md` — ready for drag-and-drop
  - **`zip -x` excludes**: strips `__pycache__`, `.pyc`, `.DS_Store` from archives

  ## Excluded skills (24)

  Auth type | Skills
  --- | ---
  API keys | discussion_partners, llm_judge, prompt_evolution, lean_prover, superforecaster, api_key_checker
  GitHub CLI | gh_cli, prior_art_review, private_repo, capture, daily_briefing, session_planner, pr_review, ralph_loop, heartbeat
  Google Workspace | gws_cli
  Modal | modal
  Slack MCP | slack_bridge
  Obsidian vault | obsidian, hierarchical_memory, remember_session, reminders, web_grab, evergreen

  ## Test plan

  - [x] `make build-web` produces 17 `.zip` files in `build/claude-ai/`
  - [x] Each zip has `SKILL.md` at root (verified with `unzip -l`)
  - [x] Scripts and reference files preserved in subdirectories
  - [x] No `__pycache__`, `.pyc`, or `.DS_Store` in any archive
  - [x] Idempotent (re-run produces same result)
  - [x] `make ci` passes

