### PR TITLE
Rewrite README: refocus on skills, drop npx install

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Packages 17 web-compatible skills (no auth required) as `.zip` files in `build/c
 - `~/claude/worktrees/` — Git worktrees for parallel development
 - `~/claude/obsidian/` — Obsidian vault for knowledge management (optional)
 
+**Per-project config** (this repo only):
+- `.claude/settings.json` — Adds `Edit(**)` and `Write(**)` for full file access. Other permissions inherit from global config.
+- `CLAUDE.md` — Repo-specific conventions, anti-patterns, and build commands.
+
 ## Development
 
 Requires [uv](https://docs.astral.sh/uv/getting-started/installation/).


### PR DESCRIPTION
## Summary

- Rewrite README to lead with what the skills do, not the obsidian pipeline
- Reorganize skill tables by function: thinking, code quality, multi-model, forecasting, knowledge management, workflow, tools
- Remove `npx skills add` install method (unverified, may not work)
- Add `make build-web` / Claude.ai install section
- Drop information hierarchy, roadmap, completed items, and lessons learned sections (that content lives in CLAUDE.md and memory)
- Net: 107 additions, 237 deletions (-130 lines)

## Test plan

- [x] `make ci` passes
- [ ] Visually review rendered markdown on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
