### PR TITLE
Add Codex CLI support and update model defaults for discussion-partners

### DIFF
--- a/.claude/skills/discussion-partners/SKILL.md
+++ b/.claude/skills/discussion-partners/SKILL.md
@@ -69,14 +69,19 @@ codex exec --full-auto -m gpt-5.4 -c model_reasoning_effort="xhigh" "Your questi
 # GPT-5.4 xhigh — long prompt from file
 codex exec --full-auto -m gpt-5.4 -c model_reasoning_effort="xhigh" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
 
-# gpt-5.3-codex — coding specialist (default model in ~/.codex/config.toml)
-codex exec --full-auto -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
+# gpt-5.3-codex coding specialist — xhigh reasoning
+codex exec --full-auto -c model_reasoning_effort="xhigh" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
 
 # GPT-5.4 with low reasoning (faster, good for large prompts)
 codex exec --full-auto -m gpt-5.4 -c model_reasoning_effort="low" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
+
+# Enable web search (--search gives the model a web_search tool)
+codex exec --full-auto --search -m gpt-5.4 -c model_reasoning_effort="xhigh" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
 ```
 
 The `-o` flag writes the final agent message to a file for easy consumption. Use `--full-auto` for non-interactive execution with workspace-write sandboxing.
+
+**Additional capabilities**: `--search` enables live web search (native Responses `web_search` tool, no per-call approval). Codex also supports MCP servers for additional tools (`codex mcp add`), and has a built-in `codex review` command for code review. Run `codex --help` and `codex exec --help` to see all available options.
 
 ### Codex CLI Setup
 


### PR DESCRIPTION
## Summary
- Add Codex CLI as first-class invocation method (gpt-5.3-codex default, gpt-5.4 with xhigh)
- Codex CLI uses OpenAI subscription credits (no per-token billing)
- Change API script default from gpt-5.4 to gemini-3.1-pro-preview
- Add gpt-5.4-pro via openai-responses: prefix (slow but extraordinary depth)
- Remove broken openai:gpt-5.1-codex and openai:codex-mini-latest API entries (404)
- Split docs: API models (ask_model.py) vs Codex CLI models (codex exec)
- Add file input examples for both methods (--file for API, stdin pipe for Codex)

Closes #194

## Test plan
- [x] Verified gpt-5.3-codex works via codex exec --full-auto
- [x] Verified gpt-5.4 works via codex exec --full-auto
- [x] Verified gpt-5.4-pro works via openai-responses: prefix
- [x] Verified gpt-5.4-pro does NOT work via openai: prefix (needs Responses API)
- [x] Verified codex-mini-latest and gpt-5.1-codex return 404 via standard API
- [x] Verified stdin piping works for long prompts
- [x] make test passes (337 unit + 5 integration)

Generated with [Claude Code](https://claude.com/claude-code)