### PR TITLE
Add thoroughness and evaluation to skill-stealer workflow

### DIFF
--- a/.claude/skills/skillcraft/evaluation.md
+++ b/.claude/skills/skillcraft/evaluation.md
@@ -171,7 +171,7 @@ When evaluating a skill created via [skill-stealer.md](skill-stealer.md), focus 
 1. **Enumerate source ideas** — List every major idea, procedure, and distinction from the original source. This is your completeness baseline.
 2. **Map to stolen skill** — For each source idea, confirm it appears in the stolen skill (possibly reworded or converted from code to prose). Flag anything missing.
 3. **Justify cuts** — Any source idea NOT in the stolen skill needs an explicit reason: "Claude already knows this", "framework-specific boilerplate", or "not applicable to our architecture". If you can't justify the cut, restore the idea.
-4. **Trigger coverage** — 5+ positive queries, 5+ negative queries. Does the `description` field surface the skill for the right requests?
+4. **Trigger coverage** — 5+ positive queries, 5+ negative queries. Do the `name` and `description` fields surface the skill for the right requests?
 5. **Functional scenarios** — 3+ realistic use cases. Walk through the skill mentally: would it produce correct output?
 6. **Freedom levels** — Are the right parts locked down (low freedom) vs. flexible (high freedom)?
 

--- a/.claude/skills/skillcraft/skill-stealer.md
+++ b/.claude/skills/skillcraft/skill-stealer.md
@@ -43,9 +43,9 @@ Apply the [skills-reference.md](skills-reference.md) checklist. The two most com
 - **Description drives discovery**: Write in third person with specific trigger terms. Claude uses descriptions to choose from 100+ skills. Include both WHEN to use and WHEN NOT to use.
 - **Provide defaults, not options**: Don't present multiple approaches unless necessary. Pick the best default, mention alternatives only as escape hatches.
 
-8. **Evaluate the stolen skill** — Before declaring done, validate completeness and quality:
+8. **Evaluate the stolen skill** — Before declaring done, apply the Stolen Skill Evaluation checklist in [evaluation.md](evaluation.md):
 
-   **a. Trigger testing** — Draft 5+ queries that SHOULD trigger the skill and 5+ that should NOT. Review the `description` field against these. Fix undertriggering (missing keywords) or overtriggering (scope too broad).
+   **a. Trigger testing** — Draft 5+ queries that SHOULD trigger the skill and 5+ that should NOT. Review the `name` and `description` fields against these. Fix undertriggering (missing keywords) or overtriggering (scope too broad).
 
    **b. Functional testing** — Draft 3+ realistic test scenarios with expected behaviors. Mentally walk through the skill: would Claude produce the right output for each scenario? Fix gaps.
 
@@ -55,7 +55,7 @@ Apply the [skills-reference.md](skills-reference.md) checklist. The two most com
 
 ## Post-Creation: Compress if Needed
 
-After evaluation passes, if the skill exceeds 150 lines, run it through the [skill-pruner.md](skill-pruner.md) (Skill Compression section) for compression.
+After evaluation passes, if the skill exceeds 150 lines, run it through the [skill-pruner.md](skill-pruner.md) (Skill Compression section) for compression. If pruning was applied, rerun the completeness audit to ensure compression didn't strip key ideas.
 
 ## Output
 


### PR DESCRIPTION
Closes #325

## Summary
The skill-stealer workflow over-compressed stolen skills (biased toward "minimum effective prompt") and never evaluated them after creation. This PR reframes Step 3 to enumerate and justify cuts before removing anything, adds a post-creation evaluation step (trigger testing, functional testing, completeness audit), and adds stolen-skill-specific evaluation guidance to evaluation.md. Post-compression re-evaluation ensures pruning doesn't re-introduce the over-compression problem.

## Sources
- Issue #325 feedback and execution plan
- Anthropic skill-creator evaluation pattern (inspiration, not copied)

## Review
- GPT-5.4 (xhigh): Approve — flagged post-pruning re-eval gap (fixed) and name+description consistency (fixed)
- Gemini 3.1 Pro: Approve — flagged missing evaluation.md link in Step 8 (fixed)
- Claude Opus: Unavailable (no ANTHROPIC_API_KEY for external calls)

## Test plan
- [x] `make test` passes (337 unit + 5 integration)
