### PR TITLE
Use Codex fast mode by default in discussion-partners

### DIFF
--- a/.claude/skills/discussion-partners/SKILL.md
+++ b/.claude/skills/discussion-partners/SKILL.md
@@ -16,20 +16,21 @@ Query another AI model for an outside perspective on a difficult problem. One me
 
 ## Recommended Models
 
-**Default: GPT-5.4 xhigh via Codex CLI** — uses OpenAI subscription credits (no per-token billing), cheapest option. Do NOT use older models like o3 or gpt-5.2 — they are superseded.
+**Default: GPT-5.4 xhigh fast via Codex CLI** — uses OpenAI subscription credits (no per-token billing), cheapest option.
 
 There are two invocation methods: the **Codex CLI** (preferred, uses subscription credits) and the **pydantic-ai script** (for non-OpenAI models and gpt-5.4-pro).
 
 ### Codex CLI Models (via `codex exec`) — preferred
 
-Uses credits from an OpenAI paid subscription (no per-token billing). Codex-only models are not accessible via the standard OpenAI API.
+Uses credits from an OpenAI paid subscription (no per-token billing).
 
 | Model | When to use | Notes |
 |-------|-------------|-------|
 | `gpt-5.4` **(default)** | Primary partner. Full GPT-5.4 with xhigh thinking | Subscription credits, cheapest option |
-| `gpt-5.3-codex` | Coding specialist — code review, debugging, refactors | Default in `~/.codex/config.toml`, Codex-only |
 
 Set reasoning effort via `-c model_reasoning_effort="xhigh"` (values: `low`, `medium`, `high`, `xhigh`). Default from config is `xhigh`.
+
+**Fast mode**: Always use `-c service_tier="fast"` (or set `service_tier = "fast"` in config). Uses 2x credits but halves latency — a clear win since Codex can be slow at xhigh reasoning.
 
 ### API Models (via `ask_model.py`)
 
@@ -63,20 +64,17 @@ Good: "Here is my auth middleware [code]. Users with expired tokens get a 500 in
 Uses OpenAI subscription credits — no per-token billing. **For short questions**, pass inline. **For long prompts, write to a file and pipe via stdin** — this avoids shell escaping issues with backticks and special characters.
 
 ```bash
-# GPT-5.4 xhigh (default recommendation) — short question
-codex exec --full-auto -m gpt-5.4 -c model_reasoning_effort="xhigh" "Your question" -o ~/claude/scratch/codex_output.txt
+# GPT-5.4 xhigh fast (default recommendation) — short question
+codex exec --full-auto -m gpt-5.4 -c service_tier="fast" -c model_reasoning_effort="xhigh" "Your question" -o ~/claude/scratch/codex_output.txt
 
-# GPT-5.4 xhigh — long prompt from file
-codex exec --full-auto -m gpt-5.4 -c model_reasoning_effort="xhigh" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
+# GPT-5.4 xhigh fast — long prompt from file
+codex exec --full-auto -m gpt-5.4 -c service_tier="fast" -c model_reasoning_effort="xhigh" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
 
-# gpt-5.3-codex coding specialist — xhigh reasoning
-codex exec --full-auto -c model_reasoning_effort="xhigh" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
-
-# GPT-5.4 with low reasoning (faster, good for large prompts)
-codex exec --full-auto -m gpt-5.4 -c model_reasoning_effort="low" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
+# GPT-5.4 with low reasoning fast (faster still, good for large prompts)
+codex exec --full-auto -m gpt-5.4 -c service_tier="fast" -c model_reasoning_effort="low" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
 
 # Enable web search (--search gives the model a web_search tool)
-codex exec --full-auto --search -m gpt-5.4 -c model_reasoning_effort="xhigh" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
+codex exec --full-auto --search -m gpt-5.4 -c service_tier="fast" -c model_reasoning_effort="xhigh" -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt.txt
 ```
 
 The `-o` flag writes the final agent message to a file for easy consumption. Use `--full-auto` for non-interactive execution with workspace-write sandboxing.
@@ -88,8 +86,9 @@ The `-o` flag writes the final agent message to a file for easy consumption. Use
 Install: `npm install -g @openai/codex` (requires Node.js). Configure `~/.codex/config.toml`:
 
 ```toml
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "xhigh"
+service_tier = "fast"
 ```
 
 Auth: `codex login` (uses your OpenAI account). No `OPENAI_API_KEY` needed — Codex CLI authenticates separately.
@@ -127,7 +126,7 @@ uv run --directory SKILL_DIR python scripts/ask_model.py -m anthropic:claude-opu
 
 ### When to Use Codex CLI vs ask_model.py
 
-- **Codex CLI** (preferred): Uses subscription credits. GPT-5.4 xhigh is the default recommendation. Codex-only models (`gpt-5.3-codex`) are only available here.
+- **Codex CLI** (preferred): Uses subscription credits. GPT-5.4 xhigh fast is the default recommendation.
 - **ask_model.py**: For Gemini, Claude, gpt-5.4-pro, or when you need multi-provider opinions. Pay-per-token.
 
 ## API Key Setup


### PR DESCRIPTION
## Summary
- Add service_tier=fast to all Codex CLI examples and config
- Remove stale gpt-5.3-codex references (migrated to gpt-5.4)
- Remove stale o3/gpt-5.2 warning

## Test plan
- make test passes (343 unit + 5 integration)
- Verified codex exec with service_tier=fast works live
- No remaining 5.3/5.2/o3 references in skill

Generated with Claude Code
