### PR TITLE
Set max effort default in settings template

### DIFF
--- a/settings.template.json
+++ b/settings.template.json
@@ -2,7 +2,8 @@
   "model": "opus",
   "env": {
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6"
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
+    "CLAUDE_CODE_EFFORT_LEVEL": "max"
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## Summary

- Add CLAUDE_CODE_EFFORT_LEVEL=max to the env block in settings.template.json
- The effortLevel settings key caps at high, but the env var supports max (Opus 4.6 only)
- After make install, max effort persists across sessions without needing /effort max

Closes #333, closes #352

## Test plan
- [ ] make install applies the new env var
- [ ] New Claude Code sessions start at max effort without manual /effort max

Generated with Claude Code
