### PR TITLE
Add Kirby Frame mental model

### DIFF
--- a/.claude/skills/mental-models/SKILL.md
+++ b/.claude/skills/mental-models/SKILL.md
@@ -141,6 +141,8 @@ These require recognition, not protocol. Knowing the name is usually enough to c
 
 **Hoare's Dictum** — Two ways to build software: so simple there are obviously no deficiencies, or so complicated there are no obvious deficiencies. The first is far harder — and far better. Prefer designs you can prove correct by inspection over designs too complex to find bugs in. See [hoares-dictum.md](hoares-dictum.md).
 
+**Kirby Frame** (Anthony Moser) — Instead of negating a bad-faith argument (which reinforces it), absorb it into a larger frame that explains what the speaker is actually doing. Named after Kirby, who inhales enemies. Don't rebut the claim — expose the rhetorical move. See [kirby-frame.md](kirby-frame.md).
+
 ## Quick Lookup
 
 A model almost always fits non-trivial problems — scan for one. Multiple models often apply simultaneously; combine as needed.
@@ -158,6 +160,7 @@ A model almost always fits non-trivial problems — scan for one. Multiple model
 - **Analyzing an argument?** → Excavate, Negspace, Rhetoricize
 - **Comparing options?** → Dimensionalize
 - **Conflicting views?** → Synthesize, Antithesize
+- **Bad-faith argument?** → Kirby Frame, Rhetoricize
 - **New domain?** → Rhyme, Metaphorize
 
 When applying: name the model, read the linked file if it has a protocol, walk through the reasoning, and note where the model might mislead.

--- a/.claude/skills/mental-models/kirby-frame.md
+++ b/.claude/skills/mental-models/kirby-frame.md
@@ -1,0 +1,49 @@
+# Kirby Frame
+
+Instead of negating a bad-faith argument (which reinforces it), absorb it into a larger frame that explains what the speaker is actually doing. Named after the video game character Kirby, who inhales enemies and gains their powers.
+
+## Core Insight
+
+Lakoff's rule: negating a frame activates the frame. Saying "I am not a crook" makes people think about crooks. The Kirby Frame goes further — don't negate, don't ignore, **eat** the frame. Respond with a bigger frame that contains and explains the original.
+
+## The Template
+
+1. **Frame** — the bad-faith claim or negative label being imposed on you
+2. **Negation** — the trap response (rebutting on their terms, which reinforces the frame)
+3. **Kirby** — what's actually happening: shift focus to the actor, their motive, and the rhetorical move they're making
+
+## Process
+
+1. **Identify the frame** — what is the opponent's claim or label? What assumptions does it smuggle in?
+2. **Name the trap** — what would a direct rebuttal look like? Note how it repeats and reinforces the original frame
+3. **Eat the frame** — construct a larger narrative that contains the opponent's claim as a *move* rather than a *fact*. Focus on the person making the argument and what they're trying to accomplish
+4. **Deliver the Kirby** — your response explains the opponent's strategy, not their claim. The audience now sees the rhetorical game, not the original accusation
+
+## Examples
+
+- **Frame:** "Why won't you condemn X?" → **Negation (trap):** "I do condemn X, and here's why..." → **Kirby:** "This is a loyalty test disguised as a question. They're not interested in your position on X — they're establishing that they get to decide what you must say."
+- **Frame:** "This policy is socialist." → **Negation (trap):** "It's not socialist because..." → **Kirby:** "They call anything that helps people 'socialist' so you'll argue about labels instead of whether the policy works."
+
+## Related Strategies
+
+- **Agree and amplify** — accept the premise and push it to absurdity (overlaps but different: Kirby reframes, A&A destabilizes)
+- **Reappropriation** — own the insult as a badge of honor ("deplorables", "nasty woman")
+- **Political jiu-jitsu** — use the opponent's force against them
+- **Lakoff's reframing** — don't negate, build your own frame (Kirby is the offensive variant: eat *their* frame into yours)
+
+## When to Use
+
+- Responding to bad-faith arguments or loaded questions
+- When direct rebuttal would reinforce the opponent's narrative
+- Political messaging and debate prep
+- Any situation where "the more you deny it, the worse it gets"
+
+## When NOT to Use
+
+- Good-faith disagreements — Kirby is for rhetorical combat, not truth-seeking
+- When the claim is factual and deserves a direct answer
+- When you don't actually understand the opponent's motive (misattributing bad faith is its own trap)
+
+## Source
+
+Anthony Moser, ["The Kirby Frame"](https://anthonymoser.github.io/writing/rhetoric/framing/kirby/2026/01/28/the-kirby-frame.html), moser's frame shop, January 2026. Built on George Lakoff's framing theory (*Don't Think of an Elephant!*, 2004).


### PR DESCRIPTION
## Summary
- Adds the **Kirby Frame** mental model from Anthony Moser's The Kirby Frame article
- Core idea: instead of negating a bad-faith argument (which reinforces it per Lakoff), absorb it into a larger frame that exposes the rhetorical move
- New file: .claude/skills/mental-models/kirby-frame.md with template, examples, related strategies, and when to use/not use
- Added to SKILL.md Design and Communication section and Quick Lookup table

## Test plan
- [ ] Verify kirby-frame.md renders correctly and links resolve
- [ ] Verify SKILL.md index entry and Quick Lookup entry are correctly placed
- [ ] Run make ci to confirm no lint/test regressions