### PR TITLE
Document gws-cli RAPT/cloud-platform scope pitfall and fresh-branch workflow

### DIFF
--- a/.claude/skills/gws-cli/SKILL.md
+++ b/.claude/skills/gws-cli/SKILL.md
@@ -147,15 +147,17 @@ gws auth login -s drive,sheets,gmail  # login with specific scopes only
 
 ### Scope selection and RAPT
 
+**WARNING: The `-s` flag silently includes `cloud-platform` scope.** Even when you specify only Workspace services (e.g. `-s gmail,drive`), the `gws` CLI adds `cloud-platform` to the token request. This triggers RAPT (Re-Authentication Proof Token) session control, which forces re-authentication every 1-24 hours (max 24hr, configured by Google Workspace admin). Workspace-only scopes (gmail, drive, docs, calendar, etc.) are NOT subject to RAPT and would produce long-lived tokens -- but you only get that benefit if `cloud-platform` is truly excluded from the token.
+
+**Workaround (unconfirmed):** Using `--scopes` with explicit full scope URLs (e.g. `https://www.googleapis.com/auth/gmail.modify`) instead of the `-s` shorthand *may* avoid the silent `cloud-platform` inclusion, but this has not been verified as of 2026-04-07.
+
 Request only the Workspace scopes you need:
 
 ```bash
 gws auth login -s gmail,calendar,drive,docs,sheets,slides,tasks
 ```
 
-Do NOT include `cloud-platform` scope unless you need GCP resource management. The `cloud-platform` scope triggers Google Workspace RAPT (Re-Authentication Proof Token) session control, which forces re-authentication every 1-24 hours depending on admin policy. Workspace-specific scopes (gmail, drive, docs, etc.) are NOT subject to RAPT and produce long-lived tokens.
-
-The `--full` flag includes `cloud-platform` -- avoid it unless you specifically need GCP access. If you are being prompted to re-authenticate frequently, re-login with only Workspace scopes to fix it.
+Do NOT include `cloud-platform` scope unless you need GCP resource management. The `--full` flag also includes `cloud-platform` -- avoid it unless you specifically need GCP access. If you are being prompted to re-authenticate frequently (daily/weekly), the cause is almost certainly `cloud-platform` scope triggering RAPT. Re-login with only Workspace scopes to fix it.
 
 ### Adding an account
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Use README.md as the development memory for this repo. It contains the skill inv
 
 Global defaults (PRs always, worktrees, atomic PRs) are in `~/CLAUDE.md`. Skills-repo specifics:
 
+- **Always branch from fresh `origin/main`**: `git fetch origin` then `git checkout -b branch-name origin/main`. Never branch from a stale local `main` -- stale bases cause merge conflicts and test failures against current deps.
 - **Worktree naming**: use `git worktree add ~/claude/worktrees/skills-<name> main` (prefix `skills-` to identify this repo's worktrees).
 - **When superseding a PR**, close the old PR directly: `gh pr close <number> --comment "Superseded by #<new>"`. Then open the new PR. You have permission to do this; the human can reopen if needed.
 


### PR DESCRIPTION
## Summary
- **gws-cli SKILL.md**: Add prominent warning that `-s` silently includes `cloud-platform` scope, triggering RAPT re-auth (max 24hr session). Document the unconfirmed `--scopes` workaround with explicit URLs. Consolidate and strengthen the existing RAPT section.
- **CLAUDE.md**: Add explicit "always branch from fresh `origin/main`" guidance to Git Workflow section, complementing the existing anti-pattern note.

## Test plan
- [x] `make test` passes (371 unit + 10 integration tests)
- [ ] Verify SKILL.md reads clearly and the warning is prominent
- [ ] Verify CLAUDE.md branching guidance is clear and non-redundant

Generated with [Claude Code](https://claude.com/claude-code)
