### PR TITLE
Expand $HOME in CLAUDE_OBSIDIAN_DIR at install time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,13 @@ install: ## Install everything: system deps, UV deps, skills, agents, config
 	@set -e; ts=$$(date +%Y%m%d%H%M%S); \
 	if [ -f "$(HOME)/.claude/settings.json" ]; then cp "$(HOME)/.claude/settings.json" "$(HOME)/.claude/settings.json.$$ts.bak"; fi; \
 	if [ -f "$(HOME)/CLAUDE.md" ]; then cp "$(HOME)/CLAUDE.md" "$(HOME)/CLAUDE.md.$$ts.bak"; fi
-	@# settings.json env values don't expand $HOME or ~ (#21551 Not Planned),
+	@# settings.json env values don't expand $$HOME or ~ (#21551 Not Planned),
 	@# so inject absolute paths at install time. Template stays public-safe.
-	@# Atomic write (tmp + mv) so a jq failure can't leave settings.json empty,
-	@# and --arg binds the path as a proper JSON string (safe vs. $HOME weirdness).
-	@tmp="$(HOME)/.claude/settings.json.tmp"; \
+	@# Atomic write via mktemp + mv so a jq failure can't leave settings.json
+	@# empty, and concurrent installs can't stomp the same temp file. --arg
+	@# binds the path as a proper JSON string (safe vs. weird path characters).
+	@tmp=$$(mktemp "$(HOME)/.claude/settings.json.XXXXXX"); \
+	trap 'rm -f "$$tmp"' EXIT; \
 	jq --arg obsidian_dir "$(HOME)/claude/obsidian" \
 		'.env.CLAUDE_OBSIDIAN_DIR = $$obsidian_dir' \
 		settings.template.json > "$$tmp" && \

--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,15 @@ install: ## Install everything: system deps, UV deps, skills, agents, config
 	@# CLAUDE_OBSIDIAN_DIR in .zshrc keeps their override), falling back to
 	@# the default. Validate absolute before writing. Atomic write via
 	@# mktemp + mv so a jq failure can't leave settings.json empty.
+	@# Also rewrite the Edit/Write permission patterns so custom vault
+	@# paths work end-to-end (env + permissions), not just the env var.
 	@set -e; \
 	obsidian_dir="$${CLAUDE_OBSIDIAN_DIR:-$(HOME)/claude/obsidian}"; \
 	case "$$obsidian_dir" in /*) ;; *) echo "ERROR: CLAUDE_OBSIDIAN_DIR must be absolute, got: $$obsidian_dir" >&2; exit 1 ;; esac; \
 	tmp=$$(mktemp "$(HOME)/.claude/settings.json.XXXXXX"); \
 	trap 'rm -f "$$tmp"' EXIT; \
 	jq --arg obsidian_dir "$$obsidian_dir" \
-		'.env.CLAUDE_OBSIDIAN_DIR = $$obsidian_dir' \
+		'.env.CLAUDE_OBSIDIAN_DIR = $$obsidian_dir | .permissions.allow |= map(if . == "Edit(~/claude/obsidian/**)" then "Edit(" + $$obsidian_dir + "/**)" elif . == "Write(~/claude/obsidian/**)" then "Write(" + $$obsidian_dir + "/**)" else . end)' \
 		settings.template.json > "$$tmp"; \
 	mv "$$tmp" "$(HOME)/.claude/settings.json"
 	@cp CLAUDE.template.md $(HOME)/CLAUDE.md

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ install: ## Install everything: system deps, UV deps, skills, agents, config
 	@# paths work end-to-end (env + permissions), not just the env var.
 	@set -e; \
 	obsidian_dir="$${CLAUDE_OBSIDIAN_DIR:-$(HOME)/claude/obsidian}"; \
-	obsidian_dir="$${obsidian_dir%/}"; \
+	while [ "$${obsidian_dir%/}" != "$$obsidian_dir" ]; do obsidian_dir="$${obsidian_dir%/}"; done; \
 	case "$$obsidian_dir" in /?*) ;; *) echo "ERROR: CLAUDE_OBSIDIAN_DIR must be an absolute path (got: $${CLAUDE_OBSIDIAN_DIR:-<unset>})" >&2; exit 1 ;; esac; \
 	echo "  Vault: $$obsidian_dir"; \
 	tmp=$$(mktemp "$(HOME)/.claude/settings.json.XXXXXX"); \

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,10 @@ install: ## Install everything: system deps, UV deps, skills, agents, config
 	@set -e; ts=$$(date +%Y%m%d%H%M%S); \
 	if [ -f "$(HOME)/.claude/settings.json" ]; then cp "$(HOME)/.claude/settings.json" "$(HOME)/.claude/settings.json.$$ts.bak"; fi; \
 	if [ -f "$(HOME)/CLAUDE.md" ]; then cp "$(HOME)/CLAUDE.md" "$(HOME)/CLAUDE.md.$$ts.bak"; fi
-	@cp settings.template.json $(HOME)/.claude/settings.json
+	@# settings.json env values don't expand $HOME or ~ (#21551 Not Planned),
+	@# so inject absolute paths at install time. Template stays public-safe.
+	@jq '.env.CLAUDE_OBSIDIAN_DIR = "$(HOME)/claude/obsidian"' \
+		settings.template.json > $(HOME)/.claude/settings.json
 	@cp CLAUDE.template.md $(HOME)/CLAUDE.md
 	@# ── Symlink skills ──
 	@set -e; for skill_dir in $(SKILLS_DIR)/*/; do \

--- a/Makefile
+++ b/Makefile
@@ -75,13 +75,16 @@ install: ## Install everything: system deps, UV deps, skills, agents, config
 	if [ -f "$(HOME)/CLAUDE.md" ]; then cp "$(HOME)/CLAUDE.md" "$(HOME)/CLAUDE.md.$$ts.bak"; fi
 	@# settings.json env values don't expand $$HOME or ~ (#21551 Not Planned),
 	@# so inject absolute paths at install time. Template stays public-safe.
-	@# Atomic write via mktemp + mv so a jq failure can't leave settings.json
-	@# empty, and concurrent installs can't stomp the same temp file. --arg
-	@# binds the path as a proper JSON string (safe vs. weird path characters).
+	@# Source the vault path from the shell env first (so a user who exports
+	@# CLAUDE_OBSIDIAN_DIR in .zshrc keeps their override), falling back to
+	@# the default. Validate absolute before writing. Atomic write via
+	@# mktemp + mv so a jq failure can't leave settings.json empty.
 	@set -e; \
+	obsidian_dir="$${CLAUDE_OBSIDIAN_DIR:-$(HOME)/claude/obsidian}"; \
+	case "$$obsidian_dir" in /*) ;; *) echo "ERROR: CLAUDE_OBSIDIAN_DIR must be absolute, got: $$obsidian_dir" >&2; exit 1 ;; esac; \
 	tmp=$$(mktemp "$(HOME)/.claude/settings.json.XXXXXX"); \
 	trap 'rm -f "$$tmp"' EXIT; \
-	jq --arg obsidian_dir "$(HOME)/claude/obsidian" \
+	jq --arg obsidian_dir "$$obsidian_dir" \
 		'.env.CLAUDE_OBSIDIAN_DIR = $$obsidian_dir' \
 		settings.template.json > "$$tmp"; \
 	mv "$$tmp" "$(HOME)/.claude/settings.json"

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,13 @@ install: ## Install everything: system deps, UV deps, skills, agents, config
 	if [ -f "$(HOME)/CLAUDE.md" ]; then cp "$(HOME)/CLAUDE.md" "$(HOME)/CLAUDE.md.$$ts.bak"; fi
 	@# settings.json env values don't expand $HOME or ~ (#21551 Not Planned),
 	@# so inject absolute paths at install time. Template stays public-safe.
-	@jq '.env.CLAUDE_OBSIDIAN_DIR = "$(HOME)/claude/obsidian"' \
-		settings.template.json > $(HOME)/.claude/settings.json
+	@# Atomic write (tmp + mv) so a jq failure can't leave settings.json empty,
+	@# and --arg binds the path as a proper JSON string (safe vs. $HOME weirdness).
+	@tmp="$(HOME)/.claude/settings.json.tmp"; \
+	jq --arg obsidian_dir "$(HOME)/claude/obsidian" \
+		'.env.CLAUDE_OBSIDIAN_DIR = $$obsidian_dir' \
+		settings.template.json > "$$tmp" && \
+	mv "$$tmp" "$(HOME)/.claude/settings.json"
 	@cp CLAUDE.template.md $(HOME)/CLAUDE.md
 	@# ── Symlink skills ──
 	@set -e; for skill_dir in $(SKILLS_DIR)/*/; do \

--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,12 @@ install: ## Install everything: system deps, UV deps, skills, agents, config
 	@# Atomic write via mktemp + mv so a jq failure can't leave settings.json
 	@# empty, and concurrent installs can't stomp the same temp file. --arg
 	@# binds the path as a proper JSON string (safe vs. weird path characters).
-	@tmp=$$(mktemp "$(HOME)/.claude/settings.json.XXXXXX"); \
+	@set -e; \
+	tmp=$$(mktemp "$(HOME)/.claude/settings.json.XXXXXX"); \
 	trap 'rm -f "$$tmp"' EXIT; \
 	jq --arg obsidian_dir "$(HOME)/claude/obsidian" \
 		'.env.CLAUDE_OBSIDIAN_DIR = $$obsidian_dir' \
-		settings.template.json > "$$tmp" && \
+		settings.template.json > "$$tmp"; \
 	mv "$$tmp" "$(HOME)/.claude/settings.json"
 	@cp CLAUDE.template.md $(HOME)/CLAUDE.md
 	@# ── Symlink skills ──

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,9 @@ install: ## Install everything: system deps, UV deps, skills, agents, config
 	@# paths work end-to-end (env + permissions), not just the env var.
 	@set -e; \
 	obsidian_dir="$${CLAUDE_OBSIDIAN_DIR:-$(HOME)/claude/obsidian}"; \
-	case "$$obsidian_dir" in /*) ;; *) echo "ERROR: CLAUDE_OBSIDIAN_DIR must be absolute, got: $$obsidian_dir" >&2; exit 1 ;; esac; \
+	obsidian_dir="$${obsidian_dir%/}"; \
+	case "$$obsidian_dir" in /?*) ;; *) echo "ERROR: CLAUDE_OBSIDIAN_DIR must be an absolute path (got: $${CLAUDE_OBSIDIAN_DIR:-<unset>})" >&2; exit 1 ;; esac; \
+	echo "  Vault: $$obsidian_dir"; \
 	tmp=$$(mktemp "$(HOME)/.claude/settings.json.XXXXXX"); \
 	trap 'rm -f "$$tmp"' EXIT; \
 	jq --arg obsidian_dir "$$obsidian_dir" \


### PR DESCRIPTION
## Summary

`settings.template.json` had `"CLAUDE_OBSIDIAN_DIR": ""` as a placeholder, which was actively **clobbering** the `export CLAUDE_OBSIDIAN_DIR="$HOME/claude/obsidian"` line in `~/.zshrc`. Two facts combine to cause this:

1. settings.json env values don't expand `$HOME` or `~` (anthropics/claude-code#21551, closed Not Planned)
2. Values defined in settings.json override the shell-inherited environment

Result: every `make install` ran the script through a Claude Code subprocess that saw `CLAUDE_OBSIDIAN_DIR=""`, so the hierarchical-memory skill hard-failed or had to be invoked with `CLAUDE_OBSIDIAN_DIR=...` prefixed inline.

## Fix

Inject the absolute path at install time via `jq`:

```makefile
@jq '.env.CLAUDE_OBSIDIAN_DIR = "$(HOME)/claude/obsidian"' \
    settings.template.json > $(HOME)/.claude/settings.json
```

- Template stays public-safe (empty string, no hardcoded `/Users/...` path in version control)
- Installed `~/.claude/settings.json` always has the right value, regardless of launch context (terminal, desktop app, launchd)
- `jq` is already a `brew install` dep, so no new moving parts

## Test plan

- [x] `jq '.env.CLAUDE_OBSIDIAN_DIR = "/Users/zach/claude/obsidian"' settings.template.json | jq -r .env` produces a full env block with the correct path
- [x] Other env vars (`CLAUDE_CODE_EFFORT_LEVEL`) are preserved by the jq filter
- [ ] After merge: `make install` → `cat ~/.claude/settings.json | jq -r .env.CLAUDE_OBSIDIAN_DIR` should show `/Users/zach/claude/obsidian`, and the knowledge-system skill should work without the inline env prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
