### PR TITLE
Statusline: drop refreshInterval 60 → 10 for snappier ticks

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -130,6 +130,26 @@ fi
 now_s=$(date +%s)
 rate_segs=()
 
+# Rate-limit fields only appear in Claude Code's JSON after the first API
+# response in a session. Cache them so timers survive session starts and
+# idle/sleep gaps (refreshInterval recomputes time-left from the stored
+# resets_at epoch each tick).
+cache_file="${HOME}/.claude/cache/statusline-rate-limits.json"
+if [ -n "$five_pct" ] || [ -n "$week_pct" ]; then
+    mkdir -p "${cache_file%/*}"
+    jq -n --arg fp "$five_pct" --arg fa "$five_at" \
+          --arg wp "$week_pct" --arg wa "$week_at" \
+          '{five_pct:$fp, five_at:$fa, week_pct:$wp, week_at:$wa}' \
+          > "$cache_file.tmp.$$" 2>/dev/null \
+        && mv "$cache_file.tmp.$$" "$cache_file"
+elif [ -r "$cache_file" ]; then
+    IFS=$'\x1F' read -r five_pct five_at week_pct week_at < <(
+        jq -r '[(.five_pct // ""), (.five_at // ""),
+                (.week_pct // ""), (.week_at // "")]
+               | map(tostring) | join("")' "$cache_file" 2>/dev/null
+    )
+fi
+
 build_rate() {
     local label=$1 pct_raw=$2 at=$3
     [ -z "$pct_raw" ] && return
@@ -138,7 +158,10 @@ build_rate() {
     seg="$(pct_color "$p")${label}:${p}%${reset}"
     if [ -n "$at" ]; then
         # Strip any fractional part — jq preserves floats, but bash arithmetic doesn't.
-        seg="${seg} ${gray}$(fmt_dur $(( ${at%.*} - now_s )))${reset}"
+        local secs_left=$(( ${at%.*} - now_s ))
+        # Skip windows whose reset has already passed (stale cache from a previous day).
+        [ "$secs_left" -le 0 ] && return
+        seg="${seg} ${gray}$(fmt_dur "$secs_left")${reset}"
     fi
     rate_segs+=("$seg")
 }

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -130,26 +130,6 @@ fi
 now_s=$(date +%s)
 rate_segs=()
 
-# Rate-limit fields only appear in Claude Code's JSON after the first API
-# response in a session. Cache them so timers survive session starts and
-# idle/sleep gaps (refreshInterval recomputes time-left from the stored
-# resets_at epoch each tick).
-cache_file="${HOME}/.claude/cache/statusline-rate-limits.json"
-if [ -n "$five_pct" ] || [ -n "$week_pct" ]; then
-    mkdir -p "${cache_file%/*}"
-    jq -n --arg fp "$five_pct" --arg fa "$five_at" \
-          --arg wp "$week_pct" --arg wa "$week_at" \
-          '{five_pct:$fp, five_at:$fa, week_pct:$wp, week_at:$wa}' \
-          > "$cache_file.tmp.$$" 2>/dev/null \
-        && mv "$cache_file.tmp.$$" "$cache_file"
-elif [ -r "$cache_file" ]; then
-    IFS=$'\x1F' read -r five_pct five_at week_pct week_at < <(
-        jq -r '[(.five_pct // ""), (.five_at // ""),
-                (.week_pct // ""), (.week_at // "")]
-               | map(tostring) | join("")' "$cache_file" 2>/dev/null
-    )
-fi
-
 build_rate() {
     local label=$1 pct_raw=$2 at=$3
     [ -z "$pct_raw" ] && return
@@ -158,10 +138,7 @@ build_rate() {
     seg="$(pct_color "$p")${label}:${p}%${reset}"
     if [ -n "$at" ]; then
         # Strip any fractional part — jq preserves floats, but bash arithmetic doesn't.
-        local secs_left=$(( ${at%.*} - now_s ))
-        # Skip windows whose reset has already passed (stale cache from a previous day).
-        [ "$secs_left" -le 0 ] && return
-        seg="${seg} ${gray}$(fmt_dur "$secs_left")${reset}"
+        seg="${seg} ${gray}$(fmt_dur $(( ${at%.*} - now_s )))${reset}"
     fi
     rate_segs+=("$seg")
 }

--- a/settings.template.json
+++ b/settings.template.json
@@ -141,6 +141,6 @@
   "statusLine": {
     "type": "command",
     "command": "bash ~/.claude/statusline-command.sh",
-    "refreshInterval": 60
+    "refreshInterval": 10
   }
 }


### PR DESCRIPTION
## Summary

Drop `statusLine.refreshInterval` from 60 to 10 seconds in `settings.template.json`. The script is a single jq + bash pass — cost is negligible — and a 10s tick crosses minute boundaries promptly after macOS sleep/wake.

## Why not cache the rate-limit payload?

Claude Code only populates the `rate_limits` JSON after the first API response in a session, so 5h/7d timers are blank on fresh sessions. My first pass cached values across sessions, but showing **stale** data from the previous night is more misleading than showing blank until the first message arrives. Blank is honest.

## Test plan

- [x] `make test` passes (lint + typecheck + 371 unit tests + integration)
- [ ] Live test on next session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)