### PR TITLE
Use top-level effortLevel setting instead of env var

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -86,7 +86,7 @@ if [ -n "$ctx_size" ]; then
     fi
 fi
 
-effort="${CLAUDE_CODE_EFFORT_LEVEL:-}"
+effort="${CLAUDE_CODE_EFFORT_LEVEL:-$(jq -r '.effortLevel // empty' "$HOME/.claude/settings.json" 2>/dev/null)}"
 case "$effort" in
     max)   effort_color="$good" ;;
     xhigh) effort_color="$info" ;;

--- a/settings.template.json
+++ b/settings.template.json
@@ -1,7 +1,7 @@
 {
   "model": "opus[1m]",
+  "effortLevel": "xhigh",
   "env": {
-    "CLAUDE_CODE_EFFORT_LEVEL": "max",
     "CLAUDE_OBSIDIAN_DIR": ""
   },
   "permissions": {


### PR DESCRIPTION
## Summary

- Replace `env.CLAUDE_CODE_EFFORT_LEVEL` in `settings.template.json` with the top-level `effortLevel` setting, which is the [documented way to persist effort across sessions](https://code.claude.com/docs/en/settings).
- Value moves from `max` → `xhigh`. The `effortLevel` setting only accepts `low|medium|high|xhigh`; `max` persists only via env var. `xhigh` is the [recommended default on Opus 4.7](https://code.claude.com/docs/en/model-config#adjust-effort-level), and `max` docs warn it "may show diminishing returns and is prone to overthinking."
- Statusline now falls back to reading `.effortLevel` from `~/.claude/settings.json` via `jq` when `CLAUDE_CODE_EFFORT_LEVEL` is unset, so the effort segment keeps rendering after the env var goes away.

## Test plan

- [x] `jq empty settings.template.json` — valid JSON
- [x] `make test` — lint, typecheck, 371 unit + 5 integration + 5 local tests all pass
- [x] Statusline smoke: with `effortLevel: "xhigh"` in a temp `~/.claude/settings.json` and no env var, the statusline renders `XHIGH` in sky blue
- [ ] `make install` on merge to rewrite `~/.claude/settings.json` — env var value (`max`) gets replaced with the new `effortLevel: xhigh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)