### PR TITLE
discussion-partners: drop codex 5.4 fallback (5.5 fully shipped)

### DIFF
--- a/.claude/skills/discussion-partners/SKILL.md
+++ b/.claude/skills/discussion-partners/SKILL.md
@@ -117,7 +117,7 @@ codex exec --full-auto --search -m gpt-5.5 -c service_tier="fast" -c model_reaso
   -o ~/claude/scratch/codex_output.txt - < ~/claude/scratch/prompt_codex.md
 ```
 
-Always `run_in_background: true` via the Bash tool. If `-m gpt-5.5` errors with "model does not exist", OpenAI's account-staged rollout hasn't reached you yet — fall back to `-m gpt-5.4`. See `troubleshooting.md`.
+Always `run_in_background: true` via the Bash tool. See `troubleshooting.md` for error handling.
 
 ### ask_model.py (Gemini / OpenAI pro via Responses API)
 

--- a/.claude/skills/discussion-partners/setup.md
+++ b/.claude/skills/discussion-partners/setup.md
@@ -29,14 +29,14 @@ fast_mode = true
 
 Both `service_tier = "fast"` and `[features].fast_mode = true` are required for persistent fast mode. Fast mode costs ~2.5× credits on GPT-5.5 in exchange for ~1.5× speed.
 
-Verify `gpt-5.5` is available to your account by sending a trivial smoke-test:
+Smoke-test with a trivial prompt:
 
 ```bash
-codex exec --full-auto -m gpt-5.5 -c service_tier="fast" -c model_reasoning_effort="low" "Say OK." -o /tmp/codex_smoketest.txt
-cat /tmp/codex_smoketest.txt
+codex exec --full-auto -m gpt-5.5 -c service_tier="fast" -c model_reasoning_effort="low" "Say OK." -o ~/claude/scratch/codex_smoketest.txt
+cat ~/claude/scratch/codex_smoketest.txt
 ```
 
-If this errors with `model "gpt-5.5" does not exist or you do not have access`, OpenAI's staged rollout hasn't reached this account yet — fall back to `-m gpt-5.4` in all examples until it does. (`codex --version` only prints the CLI version, not the model picker, so it can't verify model availability on its own.)
+If this errors with `model "gpt-5.5" does not exist or you do not have access`, your ChatGPT tier may not include Codex — see `troubleshooting.md`.
 
 ## ask_model.py (Gemini + OpenAI pro via Responses API)
 

--- a/.claude/skills/discussion-partners/troubleshooting.md
+++ b/.claude/skills/discussion-partners/troubleshooting.md
@@ -4,16 +4,6 @@ Reference for when one of the three paths errors. Read this after checking `setu
 
 ## Codex CLI
 
-### `The model "gpt-5.5" does not exist or you do not have access to it.`
-
-OpenAI's GPT-5.5 rollout to Codex CLI is account-staged — even on Codex CLI ≥ 0.28.0, some accounts see the model before others. Temporary fallback:
-
-```bash
-codex exec --full-auto -m gpt-5.4 -c service_tier="fast" -c model_reasoning_effort="xhigh" ...
-```
-
-Retry `gpt-5.5` periodically; update `~/.codex/config.toml` once the picker shows it.
-
 ### `codex: command not found`
 
 Codex CLI isn't installed. See `setup.md`.


### PR DESCRIPTION
## Summary
- GPT-5.5 is fully rolled out in Codex CLI; remove the staged-rollout fallback to 5.4 from SKILL.md / troubleshooting.md / setup.md.
- Pro-tier refs (\`openai-responses:gpt-5.4-pro\`) stay — 5.5-pro is still not in the API.
- Drive-by: setup.md smoke-test now writes to \`~/claude/scratch/\` instead of \`/tmp/\` (Claude Code can't auto-approve \`/tmp\` writes on macOS).

## Test plan
- [x] \`make ci\` — lint, typecheck, 381 unit tests pass
- [x] No remaining codex-context \`gpt-5.4\` references; only pro-tier API refs remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)