### PR TITLE
Validate skill frontmatter limits

### DIFF
--- a/.claude/skills/knowledge-system/SKILL.md
+++ b/.claude/skills/knowledge-system/SKILL.md
@@ -4,15 +4,15 @@ description: >
   Persistent knowledge management for Obsidian vault, notes, memories,
   reminders, and vault maintenance. Use when the user wants to save, recall,
   search, aggregate, link, organize, or clean up knowledge base/vault/memory
-  information. Triggers: obsidian, vault, knowledge base/graph, remember,
-  save to vault, save a note, capture this, inbox, route/file/log/note this,
-  create a note, daily/monthly/overall memory, what do you know/remember
-  about X, recall, what did we discuss, what do I have on, aggregate
-  memories, check memory, find/search my notes/vault, link notes,
-  organize knowledge, MOC, map of content, wiki-links, remind me, set a
-  reminder, don't let me forget, follow up on, vault maintenance, tidy up,
-  clean the vault, run maintenance, stale/orphan notes, broken links, or any
-  obsidian vault path or knowledge_graph mention. Do NOT use for code docs
+  information. Triggers: obsidian, vault, knowledge base, knowledge graph,
+  remember this, save to vault, save a note, save this, capture this, inbox,
+  route/file/log/note this, note this down, create a note,
+  daily/monthly/overall memory, what do you know/remember about X, recall,
+  what did we discuss, what do I have on, aggregate memories, check memory,
+  find/search my notes/vault, link notes, organize knowledge, MOC, map of
+  content, wiki-links, remind me, set a reminder, don't let me forget,
+  follow up on, vault maintenance, tidy up, clean the vault, run maintenance,
+  staleness, stale/orphan notes, broken links. Do NOT use for code docs
   (CLAUDE.md, AGENTS.md), codebase behavior (use staff-engineer), live status,
   or session briefings/wrap-ups (use session-lifecycle).
 allowed-tools: Bash(uv run *), Bash(git *), Bash(gh *), Bash(obsidian *), Read, Write, Glob, Grep

--- a/.claude/skills/knowledge-system/SKILL.md
+++ b/.claude/skills/knowledge-system/SKILL.md
@@ -1,27 +1,20 @@
 ---
 name: knowledge-system
 description: >
-  Persistent knowledge management for the Obsidian vault, notes, memories,
+  Persistent knowledge management for Obsidian vault, notes, memories,
   reminders, and vault maintenance. Use when the user wants to save, recall,
-  search, or organize information in the knowledge base, vault, or memory.
-  Triggers: "obsidian", "vault", "knowledge base", "knowledge graph",
-  "remember", "remember this", "remember this for later", "save to vault",
-  "save a note", "save this", "capture this", "inbox", "route this",
-  "file this", "log this", "note this down", "create a note", "daily note",
-  "monthly note", "overall memory", "what do you know about X from our notes",
-  "what do you remember about X", "recall", "what did we discuss",
-  "what do I have on", "aggregate", "aggregate memories", "aggregation",
-  "check memory", "find my notes on", "search my vault", "search notes",
-  "add to my knowledge base", "link notes", "organize knowledge", "MOC",
-  "map of content", "wiki-links", "remind me", "set a reminder",
-  "don't let me forget", "follow up on", "vault maintenance", "tidy up",
-  "clean the vault", "prune branches", "run maintenance", "staleness",
-  "stale notes", "orphan notes", "broken links". Also triggers on any
-  mention of the obsidian vault path or knowledge_graph directory.
-  Do NOT use for code-specific documentation (CLAUDE.md, AGENTS.md),
-  codebase questions about how code works (use staff-engineer), live status
-  questions, or session-wide briefings and wrap-ups like "remember this
-  session" or "save what we did today" (use session-lifecycle for those).
+  search, aggregate, link, organize, or clean up knowledge base/vault/memory
+  information. Triggers: obsidian, vault, knowledge base/graph, remember,
+  save to vault, save a note, capture this, inbox, route/file/log/note this,
+  create a note, daily/monthly/overall memory, what do you know/remember
+  about X, recall, what did we discuss, what do I have on, aggregate
+  memories, check memory, find/search my notes/vault, link notes,
+  organize knowledge, MOC, map of content, wiki-links, remind me, set a
+  reminder, don't let me forget, follow up on, vault maintenance, tidy up,
+  clean the vault, run maintenance, stale/orphan notes, broken links, or any
+  obsidian vault path or knowledge_graph mention. Do NOT use for code docs
+  (CLAUDE.md, AGENTS.md), codebase behavior (use staff-engineer), live status,
+  or session briefings/wrap-ups (use session-lifecycle).
 allowed-tools: Bash(uv run *), Bash(git *), Bash(gh *), Bash(obsidian *), Read, Write, Glob, Grep
 ---
 

--- a/.claude/skills/mental-models/SKILL.md
+++ b/.claude/skills/mental-models/SKILL.md
@@ -1,21 +1,20 @@
 ---
 name: mental-models
 description: >
-  Applies mental models to decisions, failures, systems, tradeoffs,
-  complexity, biases, strategy, epistemology/software philosophy. Use when:
-  think through, trade-offs/pros/cons, should I, analyze decision, missing
-  angles, steel man, devil's advocate, root cause, five whys,
-  post/pre-mortem, what could go wrong. Triggers: too complex,
-  over-engineering, keep it simple/KISS, simplify, grug brain, premature
-  abstraction, clever code, Hoare, one/two-way door, opportunity cost,
-  exploit vs explore, decision paralysis, bottleneck, feedback loop,
-  leverage point, emergent, compounding, technical debt, bias, sunk cost,
-  anchoring, confirmation bias, incentives, Goodhart, Chesterton's fence,
-  antifragile, Lindy, margin of safety, hidden assumptions, framing, bad
-  faith, reframe, first principles, 80/20, Pareto, Occam, OODA, defense in
-  depth, wrong framework, circle of competence, pattern language, scout
-  mindset, countermeasure not caveat, second order effects, unintended
-  consequences. Do NOT use for implementation tasks.
+  Applies mental models to decisions, tradeoffs, failures, biases, complexity,
+  epistemology. Use when: think through, trade-offs/pros/cons, should I,
+  analyze decision, missing angles, steel man, devil's advocate, debug this,
+  root cause, five whys, post/pre-mortem, overthinking, analysis paralysis,
+  what went wrong, why did this fail, what could go wrong. Triggers: too
+  complex, over-engineering, keep it simple/KISS, simplify, grug brain,
+  premature abstraction, clever code, one/two-way door, opportunity cost,
+  exploit vs explore, decision paralysis, bottleneck, feedback loop, leverage
+  point, emergent, compounding, technical debt, bias, sunk cost, anchoring,
+  confirmation bias, Dunning-Kruger, impostor syndrome, incentives, Goodhart,
+  Chesterton's fence, antifragile, margin of safety, hidden assumptions,
+  framing, bad faith, reframe, first principles, defense in depth, wrong
+  framework, circle of competence, scout mindset, second order effects,
+  unintended consequences. Do NOT use for implementation tasks.
 ---
 
 Select and apply the most relevant mental models from this toolkit. For models with full protocols, read the linked file before applying.

--- a/.claude/skills/mental-models/SKILL.md
+++ b/.claude/skills/mental-models/SKILL.md
@@ -1,44 +1,21 @@
 ---
 name: mental-models
 description: >
-  Applies mental models and structured thinking frameworks to reason about
-  problems, decisions, and systems.
-
-  Use when the user says or implies:
-  "think through", "trade-offs", "should I", "pros and cons",
-  "analyze this decision", "what am I missing", "steel man",
-  "devil's advocate", "structured way to think about this",
-  "why did this fail", "what went wrong", "root cause", "debug this",
-  "five whys", "post-mortem", "pre-mortem", "what could go wrong",
-  "too complex", "over-engineering", "keep it simple", "KISS", "simplify",
-  "complexity", "complexity demon", "grug brain", "premature abstraction",
-  "clever code", "too many layers", "spaghetti code", "worse is better",
-  "obviously correct", "Hoare",
-  "one-way door", "two-way door", "reversible", "can we undo this",
-  "opportunity cost", "exploit vs explore", "diminishing returns",
-  "decision paralysis", "analysis paralysis", "overthinking",
-  "bottleneck", "feedback loop", "leverage point", "emergent",
-  "compounding", "technical debt", "slow drift", "accumulation",
-  "bias", "am I biased", "cognitive bias", "sunk cost", "anchoring",
-  "Dunning-Kruger", "confirmation bias", "impostor syndrome",
-  "incentives", "principal-agent", "Goodhart", "gaming the metric",
-  "Chesterton's fence", "why does this exist", "before removing",
-  "antifragile", "Lindy", "margin of safety",
-  "hidden assumptions", "what's not being said", "framing", "rhetoric",
-  "bad faith", "reframe", "Kirby frame",
-  "first principles", "80/20", "Pareto", "Occam", "OODA",
-  "defense in depth", "Swiss cheese",
-  "limits of rationality", "get out of the car", "cactus person",
-  "wrong framework", "not quantifiable", "beyond analysis",
-  "circle of competence", "out of my depth", "new domain",
-  "pattern language", "scout mindset", "make this actionable",
-  "countermeasure not caveat", "second order effects",
-  "unintended consequences", "downstream effects".
-
-  Covers decision making, systems thinking, problem solving, critical analysis,
-  cognitive biases, strategic reasoning, complexity management, epistemology,
-  and software philosophy. Do NOT use for straightforward implementation tasks
-  with clear requirements.
+  Applies mental models to decisions, failures, systems, tradeoffs,
+  complexity, biases, strategy, epistemology/software philosophy. Use when:
+  think through, trade-offs/pros/cons, should I, analyze decision, missing
+  angles, steel man, devil's advocate, root cause, five whys,
+  post/pre-mortem, what could go wrong. Triggers: too complex,
+  over-engineering, keep it simple/KISS, simplify, grug brain, premature
+  abstraction, clever code, Hoare, one/two-way door, opportunity cost,
+  exploit vs explore, decision paralysis, bottleneck, feedback loop,
+  leverage point, emergent, compounding, technical debt, bias, sunk cost,
+  anchoring, confirmation bias, incentives, Goodhart, Chesterton's fence,
+  antifragile, Lindy, margin of safety, hidden assumptions, framing, bad
+  faith, reframe, first principles, 80/20, Pareto, Occam, OODA, defense in
+  depth, wrong framework, circle of competence, pattern language, scout
+  mindset, countermeasure not caveat, second order effects, unintended
+  consequences. Do NOT use for implementation tasks.
 ---
 
 Select and apply the most relevant mental models from this toolkit. For models with full protocols, read the linked file before applying.

--- a/.claude/skills/skillcraft/skills-reference.md
+++ b/.claude/skills/skillcraft/skills-reference.md
@@ -97,8 +97,8 @@ description: What this does and when to use it
 
 | Field | Required | Constraints |
 |:------|:---------|:------------|
-| `name` | Yes | Max 64 chars, lowercase letters/numbers/hyphens only. No XML tags. No reserved words ("anthropic", "claude") |
-| `description` | Yes | Max 1024 chars, non-empty, no XML tags. Include WHAT it does and WHEN to use it |
+| `name` | Yes | Lowercase kebab-case, length/format enforced by `tests/unit/test_skills.py`. No XML tags. No reserved words ("anthropic", "claude") |
+| `description` | Yes | Non-empty, max length enforced by `tests/unit/test_skills.py`, no XML tags. Include WHAT it does and WHEN to use it |
 
 **Claude Code extensions**:
 

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -52,14 +52,18 @@ class TestSkillStructure:
             f"description too long: {len(desc)} > {MAX_DESCRIPTION_LENGTH}"
         )
 
-    def test_snake_case_name(self, skill_dir: Path) -> None:
+    def test_kebab_case_name(self, skill_dir: Path) -> None:
         name = skill_dir.name
-        assert len(name) <= MAX_SKILL_NAME_LENGTH, (
-            f"directory name too long: {len(name)} > {MAX_SKILL_NAME_LENGTH}"
+        assert 0 < len(name) <= MAX_SKILL_NAME_LENGTH, (
+            f"directory name length {len(name)} must be in 1..{MAX_SKILL_NAME_LENGTH}"
         )
         assert name == name.lower(), "directory name must be lowercase"
-        assert " " not in name, "directory name must not contain spaces"
-        assert name.replace("-", "").isalnum(), "directory name must be alphanumeric with hyphens"
+        assert name[0].isalpha(), "directory name must start with a letter"
+        parts = name.split("-")
+        assert all(parts), "directory name must not have leading/trailing/consecutive hyphens"
+        assert all(p.isalnum() for p in parts), (
+            "directory name must be alphanumeric segments joined by single hyphens"
+        )
 
     def test_no_xml_angle_brackets_in_frontmatter(self, skill_dir: Path) -> None:
         text = (skill_dir / "SKILL.md").read_text()

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -10,6 +10,8 @@ import pytest
 SKILLS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "skills"
 SKILL_DIRS = sorted(d for d in SKILLS_DIR.iterdir() if d.is_dir() and d.name != "__pycache__")
 SKILL_DIRS_WITH_SCRIPTS = sorted(d for d in SKILL_DIRS if (d / "scripts").exists())
+MAX_SKILL_NAME_LENGTH = 64
+MAX_DESCRIPTION_LENGTH = 1024
 
 
 @pytest.fixture(params=[d.name for d in SKILL_DIRS], ids=lambda n: n)
@@ -35,22 +37,38 @@ class TestSkillStructure:
     def test_name_matches_directory(self, skill_dir: Path) -> None:
         text = (skill_dir / "SKILL.md").read_text()
         post = frontmatter.loads(text)
-        assert post.metadata.get("name") == skill_dir.name, (
-            f"name '{post.metadata.get('name')}' doesn't match directory '{skill_dir.name}'"
-        )
+        name = post.metadata["name"]
+        assert isinstance(name, str), "frontmatter 'name' must be a string"
+        assert name == skill_dir.name, f"name '{name}' doesn't match directory '{skill_dir.name}'"
 
     def test_description_not_empty(self, skill_dir: Path) -> None:
         text = (skill_dir / "SKILL.md").read_text()
         post = frontmatter.loads(text)
-        desc = post.metadata.get("description", "").strip()
+        desc = post.metadata["description"]
+        assert isinstance(desc, str), "frontmatter 'description' must be a string"
+        desc = desc.strip()
         assert len(desc) > 20, "description too short — should explain when to use"
+        assert len(desc) <= MAX_DESCRIPTION_LENGTH, (
+            f"description too long: {len(desc)} > {MAX_DESCRIPTION_LENGTH}"
+        )
 
     def test_snake_case_name(self, skill_dir: Path) -> None:
         name = skill_dir.name
+        assert len(name) <= MAX_SKILL_NAME_LENGTH, (
+            f"directory name too long: {len(name)} > {MAX_SKILL_NAME_LENGTH}"
+        )
         assert name == name.lower(), "directory name must be lowercase"
         assert " " not in name, "directory name must not contain spaces"
-        assert name.replace("-", "").replace("_", "").isalnum(), (
-            "directory name must be alphanumeric with hyphens/underscores"
+        assert name.replace("-", "").isalnum(), "directory name must be alphanumeric with hyphens"
+
+    def test_no_xml_angle_brackets_in_frontmatter(self, skill_dir: Path) -> None:
+        text = (skill_dir / "SKILL.md").read_text()
+        post = frontmatter.loads(text)
+        name = post.metadata["name"]
+        desc = post.metadata["description"]
+        assert "<" not in name and ">" not in name, "name must not contain XML angle brackets"
+        assert "<" not in desc and ">" not in desc, (
+            "description must not contain XML angle brackets"
         )
 
     def test_description_uses_standard_pattern(self, skill_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- compact knowledge-system and mental-models descriptions under Codex's 1024-character limit
- add simple deterministic SKILL.md frontmatter checks for name/description types, max lengths, hyphenated names, and XML angle brackets

## Validation
- make test