### PR TITLE
statusline: read effort from payload + branch/alien glyphs

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 # Claude Code status line.
 #
-# Left:   ~/path   branch
+# Left:   ~/path  ⎇ branch
 # Middle: 5h:NN% NhNm · 7d:NN% NdNh       (Claude.ai rate limits; each optional)
-# Right:   Model · ctx-mode · EFFORT · ctx:NN%
+# Right:  ❋ Model · ctx-mode · EFFORT · ctx:NN%
 #
-# Dependencies: jq, git, a Nerd Font (for the  branch and  alien glyphs).
+# Dependencies: jq, git. The ⎇ and ❋ glyphs are standard Unicode (Misc
+# Technical / Dingbats); render in any reasonable monospace font — no
+# Nerd Font needed.
 #
 # Palette uses ColorBrewer qualitative + sequential scales mapped to the
 # 256-color terminal palette. Green = good, gold = warn, red = bad, blue =
@@ -159,13 +161,13 @@ join_segs() {
 
 left=""
 [ -n "$short_cwd" ] && left+="${path_blue}${bold}${short_cwd}${reset}"
-[ -n "$branch" ]    && left+="  ${gray}${bold} ${branch}${reset}"
+[ -n "$branch" ]    && left+="  ${gray}${bold}⎇ ${branch}${reset}"
 
 middle=""
 [ "${#rate_segs[@]}" -gt 0 ] && middle=$(join_segs "${rate_segs[@]}")
 
 right_segs=()
-[ -n "$model" ]          && right_segs+=("${model_color} ${model}${reset}")
+[ -n "$model" ]          && right_segs+=("${model_color}❋ ${model}${reset}")
 [ -n "$ctx_mode" ]       && right_segs+=("${ctx_mode_color}${ctx_mode}${reset}")
 [ -n "$effort_display" ] && right_segs+=("${effort_color}${effort_display}${reset}")
 [ -n "$ctx_pct_part" ]   && right_segs+=("$ctx_pct_part")

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Claude Code status line.
 #
-# Left:   ~/path  branch
+# Left:   ~/path   branch
 # Middle: 5h:NN% NhNm · 7d:NN% NdNh       (Claude.ai rate limits; each optional)
-# Right:  Model · ctx-mode · EFFORT · ctx:NN%
+# Right:   Model · ctx-mode · EFFORT · ctx:NN%
 #
-# Dependencies: jq, git.
+# Dependencies: jq, git, a Nerd Font (for the  branch and  alien glyphs).
 #
 # Palette uses ColorBrewer qualitative + sequential scales mapped to the
 # 256-color terminal palette. Green = good, gold = warn, red = bad, blue =
@@ -41,7 +41,7 @@ pct_crit=$'\033[38;5;124m'      # YlOrRd dark red
 # fields like it does with tab/space IFS. Process substitution (not a pipe
 # into read) keeps the variables in this shell.
 input=$(cat)
-IFS=$'\x1F' read -r cwd model model_id ctx_size used_pct five_pct five_at week_pct week_at < <(
+IFS=$'\x1F' read -r cwd model model_id ctx_size used_pct five_pct five_at week_pct week_at effort < <(
     jq -r '[(.workspace.current_dir // .cwd // ""),
             (.model.display_name // ""),
             (.model.id // ""),
@@ -50,7 +50,8 @@ IFS=$'\x1F' read -r cwd model model_id ctx_size used_pct five_pct five_at week_p
             (.rate_limits.five_hour.used_percentage // ""),
             (.rate_limits.five_hour.resets_at // ""),
             (.rate_limits.seven_day.used_percentage // ""),
-            (.rate_limits.seven_day.resets_at // "")]
+            (.rate_limits.seven_day.resets_at // ""),
+            (.effort.level // "")]
            | map(tostring) | join("\u001F")' <<< "$input"
 )
 
@@ -86,7 +87,6 @@ if [ -n "$ctx_size" ]; then
     fi
 fi
 
-effort="${CLAUDE_CODE_EFFORT_LEVEL:-}"
 case "$effort" in
     max)   effort_color="$good" ;;
     xhigh) effort_color="$info" ;;
@@ -159,13 +159,13 @@ join_segs() {
 
 left=""
 [ -n "$short_cwd" ] && left+="${path_blue}${bold}${short_cwd}${reset}"
-[ -n "$branch" ]    && left+="  ${gray}${bold}${branch}${reset}"
+[ -n "$branch" ]    && left+="  ${gray}${bold} ${branch}${reset}"
 
 middle=""
 [ "${#rate_segs[@]}" -gt 0 ] && middle=$(join_segs "${rate_segs[@]}")
 
 right_segs=()
-[ -n "$model" ]          && right_segs+=("${model_color}${model}${reset}")
+[ -n "$model" ]          && right_segs+=("${model_color} ${model}${reset}")
 [ -n "$ctx_mode" ]       && right_segs+=("${ctx_mode_color}${ctx_mode}${reset}")
 [ -n "$effort_display" ] && right_segs+=("${effort_color}${effort_display}${reset}")
 [ -n "$ctx_pct_part" ]   && right_segs+=("$ctx_pct_part")


### PR DESCRIPTION
## Summary

- **Effort:** the script read effort from `\$CLAUDE_CODE_EFFORT_LEVEL`, which Claude Code only sets for `max` — `low`/`medium`/`high`/`xhigh` were silently dropped. Now reads `.effort.level` from the [statusline JSON payload](https://code.claude.com/docs/en/statusline.md) so every level renders.
- **Glyphs:** add Nerd Font glyphs in front of the branch (` `, Powerline U+E0A0) and the model (``, nf-md-alien U+F85D). Without a Nerd Font, both render as tofu; the rest of the line is unaffected.

## Test plan

- [x] Smoke-tested `low` / `medium` / `high` / `xhigh` / `max` with synthetic JSON payloads — every level renders with the correct color
- [x] Smoke-tested with `.effort` absent and with `.effort.level=""` — both correctly omit the segment
- [x] Verified branch and alien glyphs render in a Nerd Font terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)